### PR TITLE
added assembly reference to fix build problem;

### DIFF
--- a/Examples/Example9.SendPacket/Example09.SendPacket.csproj
+++ b/Examples/Example9.SendPacket/Example09.SendPacket.csproj
@@ -97,6 +97,10 @@
       <Project>{24262E52-1304-4A25-8F73-A3B06E40592E}</Project>
       <Name>SharpPcap</Name>
     </ProjectReference>
+     <Reference Include="PacketDotNet, Version=0.10.0.0, Culture=neutral, PublicKeyToken=null">
+       <SpecificVersion>False</SpecificVersion>
+	   <HintPath>..\..\SharpPcap\PacketDotNet\PacketDotNet.dll </HintPath>
+     </Reference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">

--- a/Examples/Example9.SendPacket/Example09.SendPacket.csproj
+++ b/Examples/Example9.SendPacket/Example09.SendPacket.csproj
@@ -76,7 +76,7 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="PacketDotNet, Version=0.10.0.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="PacketDotNet, Version=0.13.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\SharpPcap\PacketDotNet\PacketDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/SharpPcap/AirPcap/AirPcapDeviceList.cs
+++ b/SharpPcap/AirPcap/AirPcapDeviceList.cs
@@ -202,7 +202,7 @@ namespace SharpPcap.AirPcap
         /// but this code is worth keeping around
         /// </summary>
         /// <returns>
-        /// A <see cref="List<AirPcapDevice>"/>
+        /// A <see cref="List{AirPcapDevice}"/>
         /// </returns>
         private static List<AirPcapDevice> GetAirPcapDevices()
         {

--- a/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
@@ -149,7 +149,7 @@ namespace SharpPcap.LibPcap
         /// A <see cref="PacketDotNet.LinkLayers"/>
         /// </param>
         /// <param name="snapshotLength">
-        /// A <see cref="System.Nullable&lt;System.Int32&gt;"/>
+        /// A <see cref="Nullable{Int}"/>
         /// </param>
         /// <param name="captureFilename">
         /// A <see cref="System.String"/>

--- a/SharpPcap/WinPcap/WinPcapDeviceList.cs
+++ b/SharpPcap/WinPcap/WinPcapDeviceList.cs
@@ -90,7 +90,7 @@ namespace SharpPcap.WinPcap
         /// A <see cref="RemoteAuthentication"/>
         /// </param>
         /// <returns>
-        /// A <see cref="List<WinPcapDevice>"/>
+        /// A <see cref="List{WinPcapDevice}"/>
         /// </returns>
         public static List<WinPcapDevice> Devices(IPAddress address,
                                                   int port,


### PR DESCRIPTION
On Ubuntu 14.04 running this version of mono:
$ mono -V
Mono JIT compiler version 3.2.8 (Debian 3.2.8+dfsg-4ubuntu1.1)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
        TLS:           __thread
        SIGSEGV:       altstack
        Notifications: epoll
        Architecture:  amd64
        Disabled:      none
        Misc:          softdebug
        LLVM:          supported, not enabled.
        GC:            sgen

I had a build error when I ran:
$ xbuild SharpPcap.sln
which reported that:
        Example9.SendPacket.cs(64,24): error CS0012: The type `PacketDotNet.Packet' is defined in an assembly that is not referenced. Consider adding a reference to assembly`PacketDotNet, Version=0.13.0.0, Culture=neutral, PublicKeyToken=null'

The enclosed patch fixes this problem, and enables me to build on this platform. The patch consists of a reference I copied from Examples/CreatingCaptureFile/CreatingCaptureFile.csproj, from the same repo. Perhaps this reference had been omitted when Examples/Example9.SendPacket/Example09.SendPacket.csproj was created.
