### PR TITLE
Add support for Npcap by calling SetDllDirectory() to the npcap folde…

### DIFF
--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -21,6 +21,7 @@ along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
@@ -39,6 +40,19 @@ namespace SharpPcap.LibPcap
         //       same directory as the assembly
         //       See http://www.mono-project.com/Interop_with_Native_Libraries#Library_Names
         private const string PCAP_DLL = "wpcap";
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool SetDllDirectory(string lpPathName);
+
+        static LibPcapSafeNativeMethods()
+        {
+            if((Environment.OSVersion.Platform != PlatformID.MacOSX) &&
+                (Environment.OSVersion.Platform != PlatformID.Unix))
+            {
+                SetDllDirectory(Path.Combine(Environment.SystemDirectory, "Npcap"));
+            }
+        }
 
         [DllImport(PCAP_DLL, CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_findalldevs(ref IntPtr /* pcap_if_t** */ alldevs, StringBuilder /* char* */ errbuf);

--- a/SharpPcap/WinPcap/SafeNativeMethods.cs
+++ b/SharpPcap/WinPcap/SafeNativeMethods.cs
@@ -19,6 +19,7 @@ along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
@@ -37,6 +38,19 @@ namespace SharpPcap.WinPcap
         //       same directory as the assembly
         //       See http://www.mono-project.com/Interop_with_Native_Libraries#Library_Names
         private const string PCAP_DLL = "wpcap";
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool SetDllDirectory(string lpPathName);
+
+        static SafeNativeMethods()
+        {
+            if((Environment.OSVersion.Platform != PlatformID.MacOSX) &&
+               (Environment.OSVersion.Platform != PlatformID.Unix))
+            {
+                SetDllDirectory(Path.Combine(Environment.SystemDirectory, "Npcap"));
+            }
+        }
 
         #region WinPcap specific
         /// <summary>


### PR DESCRIPTION
…r on non-unix and non-mac platforms

Winpcap hasn't been maintained for a number of years, npcap is an actively maintained replacement.

Initial patch from Yang Luo (github account hsluoyz) and thanks to Yang for his work on npcap.