### PR TITLE
Add support for setting monitor mode when opening an adapter

### DIFF
--- a/SharpPcap/ICaptureDevice.cs
+++ b/SharpPcap/ICaptureDevice.cs
@@ -83,6 +83,20 @@ namespace SharpPcap
         void Open(DeviceMode mode, int read_timeout);
 
         /// <summary>
+        /// Open the device. To start capturing call the 'StartCapture' function
+        /// </summary>
+        /// <param name="mode">
+        /// A <see cref="DeviceMode"/>
+        /// </param>
+        /// <param name="read_timeout">
+        /// A <see cref="System.Int32"/>
+        /// </param>
+        /// <param name="monitor_mode">
+        /// A <see cref="MonitorMode"/>
+        /// </param>
+        void Open(DeviceMode mode, int read_timeout, MonitorMode monitor_mode);
+
+        /// <summary>
         /// Closes this adapter
         /// </summary>
         void Close();

--- a/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
@@ -103,7 +103,8 @@ namespace SharpPcap.LibPcap
         /// </summary>
         public override void Open()
         {
-            // Nothing to do here, device is already opened upon construction
+            // Nothing to do here, device is already opened and active upon construction
+            Active = true;
         }
 
         /// <summary>

--- a/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
@@ -209,7 +209,8 @@ namespace SharpPcap.LibPcap
         /// </summary>
         public override void Open()
         {
-            // Nothing to do here, device is already opened upon construction
+            // Nothing to do here, device is already opened and active upon construction
+            Active = true;
         }
 
         /// <summary>

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -61,7 +61,7 @@ namespace SharpPcap.LibPcap
         internal extern static void pcap_freealldevs(IntPtr /* pcap_if_t * */ alldevs);
 
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /* pcap_t* */ pcap_open_live(string dev, int packetLen, int promisc, int to_ms, StringBuilder errbuf);
+        internal extern static IntPtr /* pcap_t* */ pcap_create(string dev, StringBuilder errbuf);
 
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static IntPtr /* pcap_t* */ pcap_open_offline( string/*const char* */ fname, StringBuilder/* char* */ errbuf );
@@ -209,6 +209,52 @@ namespace SharpPcap.LibPcap
         /// </returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_snapshot(IntPtr /* pcap_t... */ adapter);
+
+        /// <summary>
+        /// pcap_set_rfmon() sets whether monitor mode should be set on a capture handle when the handle is activated.
+        /// If rfmon is non-zero, monitor mode will be set, otherwise it will not be set.  
+        /// </summary>
+        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <param name="rfmon">A <see cref="System.Int32"/></param>
+        /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
+        [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_set_rfmon(IntPtr /* pcap_t* */ p, int rfmon);
+
+        /// <summary>
+        /// pcap_set_snaplen() sets the snapshot length to be used on a capture handle when the handle is activated to snaplen.  
+        /// </summary>
+        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <param name="snaplen">A <see cref="System.Int32"/></param>
+        /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
+        [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_set_snaplen(IntPtr /* pcap_t* */ p, int snaplen);
+
+        /// <summary>
+        /// pcap_set_promisc() sets whether promiscuous mode should be set on a capture handle when the handle is activated. 
+        /// If promisc is non-zero, promiscuous mode will be set, otherwise it will not be set.  
+        /// </summary>
+        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <param name="promisc">A <see cref="System.Int32"/></param>
+        /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
+        [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_set_promisc(IntPtr /* pcap_t* */ p, int promisc);
+
+        /// <summary>
+        /// pcap_set_timeout() sets the packet buffer timeout that will be used on a capture handle when the handle is activated to to_ms, which is in units of milliseconds.
+        /// </summary>
+        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <param name="to_ms">A <see cref="System.Int32"/></param>
+        /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
+        [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_set_timeout(IntPtr /* pcap_t* */ p, int to_ms);
+
+        /// <summary>
+        /// pcap_activate() is used to activate a packet capture handle to look at packets on the network, with the options that were set on the handle being in effect.  
+        /// </summary>
+        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <returns>Returns 0 on success without warnings, a non-zero positive value on success with warnings, and a negative value on error. A non-zero return value indicates what warning or error condition occurred.</returns>
+        [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_activate(IntPtr /* pcap_t* */ p);
 
         #region libpcap specific
         /// <summary>

--- a/SharpPcap/MonitorMode.cs
+++ b/SharpPcap/MonitorMode.cs
@@ -1,0 +1,42 @@
+﻿/*
+This file is part of SharpPcap.
+
+SharpPcap is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SharpPcap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* 
+ * Copyright 2017 Noah Potash <noah.potash@outbreaklabs.com>
+ */
+
+using System;
+
+namespace SharpPcap
+{
+    /// <summary>
+    /// The activation of monitor mode used when opening a device
+    /// </summary>
+    public enum MonitorMode : short
+    {
+        /// <summary>
+        /// Monitor mode.
+        /// Allows capturing of 802.11 wireless packets even when not associated
+        /// with a network.
+        /// </summary>
+        Active = 1,
+
+        /// <summary>
+        /// Not monitor mode
+        /// </summary>
+        Inactive = 0
+    }
+}

--- a/SharpPcap/SharpPcap.csproj
+++ b/SharpPcap/SharpPcap.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
@@ -112,6 +112,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="CaptureDeviceList.cs" />
+    <Compile Include="MonitorMode.cs" />
     <Compile Include="PcapException.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
This PR addresses https://github.com/chmorgan/sharppcap/issues/27, adding support for setting monitor mode when opening an adapter. When used against Npcap or another implementation of LibPcap which supports it, this allows you to capture 802.11 packets.

An overload of the Open method has been added to ICaptureDevice which exposes the monitor_mode option. The underlying implementation of Open has been rewritten to use the more advanced procedure of creating, configuring, and then activating an adapter, and the simpler methods have all been changed to chain into it.

Because getting the Link type can only be done when an adapter is Active (rather than merely created/opened), the Link type caching has been moved from the Open setter to a new Active setter.