### PR TITLE
Allow creating pcap devices without refresh

### DIFF
--- a/SharpPcap/AirPcap/AirPcapDeviceList.cs
+++ b/SharpPcap/AirPcap/AirPcapDeviceList.cs
@@ -196,6 +196,20 @@ namespace SharpPcap.AirPcap
         }
         #endregion
 
+        #region Device Factory
+        /// <param name="Name">The name or description of the pcap interface to get.</param>
+        public AirPcapDevice Create(string Name)
+        {
+            // lock to prevent issues with multi-threaded access
+            // with other methods
+            lock (this)
+            {
+                var device = this[Name];
+                return new AirPcapDevice(new WinPcap.WinPcapDevice(device.Interface));
+            }
+        }
+        #endregion
+
         /// <summary>
         /// Example showing how to retrieve a list of AirPcap devices
         /// We can't use this because AirPcap devices don't have a pcap handle

--- a/SharpPcap/LibPcap/LibPcapLiveDeviceList.cs
+++ b/SharpPcap/LibPcap/LibPcapLiveDeviceList.cs
@@ -205,5 +205,19 @@ namespace SharpPcap.LibPcap
             }
         }
         #endregion
+
+        #region PcapDevice Factory
+        /// <param name="Name">The name or description of the pcap interface to get.</param>
+        public LibPcapLiveDevice Create(string Name)
+        {
+            // lock to prevent issues with multi-threaded access
+            // with other methods
+            lock (this)
+            {
+                var device = this[Name];
+                return new LibPcapLiveDevice(device.Interface);
+            }
+        }
+        #endregion
     }
 }

--- a/SharpPcap/WinPcap/WinPcapDeviceList.cs
+++ b/SharpPcap/WinPcap/WinPcapDeviceList.cs
@@ -268,6 +268,20 @@ namespace SharpPcap.WinPcap
             }
         }
         #endregion
+
+        #region Device Factory
+        /// <param name="Name">The name or description of the pcap interface to get.</param>
+        public WinPcapDevice Create(string Name)
+        {
+            // lock to prevent issues with multi-threaded access
+            // with other methods
+            lock (this)
+            {
+                var device = this[Name];
+                return new WinPcapDevice(device.Interface);
+            }
+        }
+        #endregion
     }
 }
 


### PR DESCRIPTION
This may be an uncommon use case, but using `Refresh()` on a `*PcapDeviceList` takes at least 50ms.
in addition to that creating a CaptureDevice with a custom filter using `New()` would implicitly perform a `Refresh()`.

I am proposing here a way of "cloning" a PcapDevice for the sake of creating a filtered capture, without the overhead of a refresh.