### PR TITLE
Added MacOSX's version of timeval structure.

### DIFF
--- a/SharpPcap/LibPcap/PcapHeader.cs
+++ b/SharpPcap/LibPcap/PcapHeader.cs
@@ -30,22 +30,30 @@ namespace SharpPcap.LibPcap
     [StructLayout(LayoutKind.Sequential, Pack = 1)] // Force it to match a 32-bit native header exactly
     public struct PcapHeader
     {
-        static readonly bool isWindows = Environment.OSVersion.Platform != PlatformID.Unix;
+        private static readonly bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        private static readonly bool isMacOSX =  RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+                                            
         static readonly bool is32BitTs = IntPtr.Size == 4 || isWindows;
 
         /// <summary>
         ///  A wrapper class for libpcap's pcap_pkthdr structure
         /// </summary>
         private unsafe PcapHeader(IntPtr pcap_pkthdr)
-        {
-            if (!isWindows) {
-                var pkthdr = *(PcapUnmanagedStructures.pcap_pkthdr_unix*)pcap_pkthdr;
+        {           
+            if (isWindows) {
+                var pkthdr = *(PcapUnmanagedStructures.pcap_pkthdr_windows*)pcap_pkthdr;
+                this.CaptureLength = pkthdr.caplen;
+                this.PacketLength = pkthdr.len;
+                this.Seconds = (uint)pkthdr.ts.tv_sec;
+                this.MicroSeconds = (uint)pkthdr.ts.tv_usec;
+            } else if (isMacOSX) {                
+                var pkthdr = *(PcapUnmanagedStructures.pcap_pkthdr_macosx*)pcap_pkthdr;
                 this.CaptureLength = pkthdr.caplen;
                 this.PacketLength = pkthdr.len;
                 this.Seconds = (uint)pkthdr.ts.tv_sec;
                 this.MicroSeconds = (uint)pkthdr.ts.tv_usec;
             } else {
-                var pkthdr = *(PcapUnmanagedStructures.pcap_pkthdr_windows*)pcap_pkthdr;
+                var pkthdr = *(PcapUnmanagedStructures.pcap_pkthdr_unix*)pcap_pkthdr;
                 this.CaptureLength = pkthdr.caplen;
                 this.PacketLength = pkthdr.len;
                 this.Seconds = (uint)pkthdr.ts.tv_sec;
@@ -130,9 +138,26 @@ namespace SharpPcap.LibPcap
         {
             IntPtr hdrPtr;
 
-            if(!isWindows)
-            {
+            if (isWindows) {
                 // setup the structure to marshal
+                var pkthdr = new PcapUnmanagedStructures.pcap_pkthdr_windows();
+                pkthdr.caplen = this.CaptureLength;
+                pkthdr.len = this.PacketLength;
+                pkthdr.ts.tv_sec = (int) this.Seconds;
+                pkthdr.ts.tv_usec = (int) this.MicroSeconds;
+
+                hdrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(PcapUnmanagedStructures.pcap_pkthdr_windows)));
+                Marshal.StructureToPtr(pkthdr, hdrPtr, true);
+            } else if (isMacOSX) {
+                var pkthdr = new PcapUnmanagedStructures.pcap_pkthdr_macosx();
+                pkthdr.caplen = this.CaptureLength;
+                pkthdr.len = this.PacketLength;
+                pkthdr.ts.tv_sec = (IntPtr)this.Seconds;
+                pkthdr.ts.tv_usec = (int) this.MicroSeconds;
+
+                hdrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(PcapUnmanagedStructures.pcap_pkthdr_macosx)));
+                Marshal.StructureToPtr(pkthdr, hdrPtr, true);                
+            } else  {
                 var pkthdr = new PcapUnmanagedStructures.pcap_pkthdr_unix();
                 pkthdr.caplen = this.CaptureLength;
                 pkthdr.len = this.PacketLength;
@@ -141,16 +166,6 @@ namespace SharpPcap.LibPcap
 
                 hdrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(PcapUnmanagedStructures.pcap_pkthdr_unix)));
                 Marshal.StructureToPtr(pkthdr, hdrPtr, true);                
-            } else
-            {
-                var pkthdr = new PcapUnmanagedStructures.pcap_pkthdr_windows();
-                pkthdr.caplen = this.CaptureLength;
-                pkthdr.len = this.PacketLength;
-                pkthdr.ts.tv_sec = (int)this.Seconds;
-                pkthdr.ts.tv_usec = (int)this.MicroSeconds;
-
-                hdrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(PcapUnmanagedStructures.pcap_pkthdr_windows)));
-                Marshal.StructureToPtr(pkthdr, hdrPtr, true);
             }
 
             return hdrPtr;

--- a/SharpPcap/LibPcap/PcapUnmanagedStructures.cs
+++ b/SharpPcap/LibPcap/PcapUnmanagedStructures.cs
@@ -165,6 +165,16 @@ namespace SharpPcap.LibPcap
             public Int32 tv_sec;
             public Int32 tv_usec;
         };
+        
+        /// <summary>
+        /// MacOSX version of struct timeval
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]    
+        public struct timeval_macosx
+        {
+            public IntPtr tv_sec;
+            public Int32 tv_usec;
+        };
         #endregion
 
         #region pcap_pkthdr
@@ -193,6 +203,15 @@ namespace SharpPcap.LibPcap
             public UInt32           caplen;         /* length of portion present */
             public UInt32           len;            /* length this packet (off wire) */
         };
+        
+        [StructLayout(LayoutKind.Sequential)]
+        public struct pcap_pkthdr_macosx
+        {
+            public timeval_macosx  ts;             /* time stamp */
+            public UInt32          caplen;         /* length of portion present */
+            public UInt32          len;            /* length this packet (off wire) */
+        };
+        
         #endregion
 
         /// <summary>


### PR DESCRIPTION
MacOSX's version of [timeval](https://developer.apple.com/documentation/kernel/timeval) uses 
[__darwin_time_t](https://opensource.apple.com/source/xnu/xnu-1228.0.2/bsd/ppc/_types.h) and  [__darwin_suseconds_t](https://opensource.apple.com/source/xnu/xnu-792/bsd/sys/_types.h) types for its fields, which are typedefs for long and int32_t respectively. On MacOSX type of tv_usec therefore differs from type in timeval_unix structure.