### PR TITLE
Proposal for setting KernelBufferSize of LibPcapDevices.

### DIFF
--- a/SharpPcap/ICaptureDevice.cs
+++ b/SharpPcap/ICaptureDevice.cs
@@ -91,10 +91,41 @@ namespace SharpPcap
         /// <param name="read_timeout">
         /// A <see cref="System.Int32"/>
         /// </param>
+        /// <param name="kernel_buffer_size">
+        /// A <see cref="System.UInt32"/>
+        /// </param>
+        void Open(DeviceMode mode, int read_timeout, uint kernel_buffer_size);
+
+        /// <summary>
+        /// Open the device. To start capturing call the 'StartCapture' function
+        /// </summary>
+        /// <param name="mode">
+        /// A <see cref="DeviceMode"/>
+        /// </param>
+        /// <param name="read_timeout">
+        /// A <see cref="System.Int32"/>
+        /// </param>
         /// <param name="monitor_mode">
         /// A <see cref="MonitorMode"/>
         /// </param>
         void Open(DeviceMode mode, int read_timeout, MonitorMode monitor_mode);
+
+        /// <summary>
+        /// Open the device. To start capturing call the 'StartCapture' function
+        /// </summary>
+        /// <param name="mode">
+        /// A <see cref="DeviceMode"/>
+        /// </param>
+        /// <param name="read_timeout">
+        /// A <see cref="System.Int32"/>
+        /// </param>
+        /// <param name="monitor_mode">
+        /// A <see cref="MonitorMode"/>
+        /// </param>
+        /// <param name="kernel_buffer_size">
+        /// A <see cref="System.UInt32"/>
+        /// </param>
+        void Open(DeviceMode mode, int read_timeout, MonitorMode monitor_mode, uint kernel_buffer_size);
 
         /// <summary>
         /// Closes this adapter

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Unix.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Unix.cs
@@ -56,6 +56,9 @@ namespace SharpPcap.LibPcap
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static IntPtr /* pcap_t* */ pcap_open_dead(int linktype, int snaplen);
 
+        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_set_buffer_size(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes);
+
         /// <summary>Open a file to write packets. </summary>
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static IntPtr /*pcap_dumper_t * */ pcap_dump_open (IntPtr /*pcap_t * */adaptHandle, string /*const char * */fname);

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Windows.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Windows.cs
@@ -60,6 +60,9 @@ namespace SharpPcap.LibPcap
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static IntPtr /* pcap_t* */ pcap_open_dead(int linktype, int snaplen);
 
+        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_set_buffer_size(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes);
+
         /// <summary>Open a file to write packets. </summary>
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static IntPtr /*pcap_dumper_t * */ pcap_dump_open (IntPtr /*pcap_t * */adaptHandle, string /*const char * */fname);

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -75,6 +75,11 @@ namespace SharpPcap.LibPcap
             return UseWindows ? Windows.pcap_open_dead(linktype, snaplen) : Unix.pcap_open_dead(linktype, snaplen);
         }
 
+        internal static int pcap_set_buffer_size(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes)
+        {
+            return UseWindows ? Windows.pcap_set_buffer_size(adapter, bufferSizeInBytes) : Unix.pcap_set_buffer_size(adapter, bufferSizeInBytes);
+        }
+
         /// <summary>Open a file to write packets. </summary>
         internal static IntPtr /*pcap_dumper_t * */ pcap_dump_open (IntPtr /*pcap_t * */adaptHandle, string /*const char * */fname)
         {

--- a/SharpPcap/LibPcap/PcapDevice.cs
+++ b/SharpPcap/LibPcap/PcapDevice.cs
@@ -233,10 +233,47 @@ namespace SharpPcap.LibPcap
         /// <param name="read_timeout">
         /// A <see cref="System.Int32"/>
         /// </param>
+        /// <param name="kernel_buffer_size">
+        /// A <see cref="System.UInt32"/>
+        /// </param>
+        public virtual void Open(DeviceMode mode, int read_timeout, uint kernel_buffer_size)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Open the device. To start capturing call the 'StartCapture' function
+        /// </summary>
+        /// <param name="mode">
+        /// A <see cref="DeviceMode"/>
+        /// </param>
+        /// <param name="read_timeout">
+        /// A <see cref="System.Int32"/>
+        /// </param>
         /// /// <param name="monitor_mode">
         /// A <see cref="MonitorMode"/>
         /// </param>
         public virtual void Open(DeviceMode mode, int read_timeout, MonitorMode monitor_mode)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Open the device. To start capturing call the 'StartCapture' function
+        /// </summary>
+        /// <param name="mode">
+        /// A <see cref="DeviceMode"/>
+        /// </param>
+        /// <param name="read_timeout">
+        /// A <see cref="System.Int32"/>
+        /// </param>
+        /// <param name="monitor_mode">
+        /// A <see cref="MonitorMode"/>
+        /// </param>
+        /// <param name="kernel_buffer_size">
+        /// A <see cref="System.UInt32"/>
+        /// </param>
+        public virtual void Open(DeviceMode mode, int read_timeout, MonitorMode monitor_mode, uint kernel_buffer_size)
         {
             throw new NotImplementedException();
         }

--- a/SharpPcap/WinPcap/WinPcapDevice.cs
+++ b/SharpPcap/WinPcap/WinPcapDevice.cs
@@ -236,7 +236,7 @@ namespace SharpPcap.WinPcap
         /// Set the kernel value buffer size in bytes
         /// WinPcap extension
         /// </value>
-        public virtual uint KernelBufferSize
+        public override uint KernelBufferSize
         {
             set
             {


### PR DESCRIPTION
Hi Chris,

first of all I want to thank you for providing and maintaining the SharpPcap library!
We are using your library to develop a monitoring tool for Industrial Communication Networks, such as EtherCAT and PROFINET. 

Next to a Windows based GUI, we are offering a Linux-Version of our tool based on .Net Core.
The capture process works fine, however we had some issues with the KernelBufferSize of LibPcap.

For the type of networks, we analyze, it is required to increase the KernelBufferSize to at least  ~25-50 MB in order to avoid packet losses.
With the current SharpPcap implementation, this is not possible for LibPcapDevices.
Therefore I have made some changes in the SharpPcap, which connect the pcap_set_buffer_size() function to the KernelBufferSize property of the LibPcapDevice
https://www.tcpdump.org/manpages/pcap_set_buffer_size.3pcap.html

With the new property for LibPcapDevices, we are now also able to use an LibPcapDevice instead of WinPcapDevice in our Windows application.
This speeds up the initialization process, because accessing CaptureDeviceList/ WinPcapDeviceList always required more time compared to LibPcapLiveDeviceList.

I have tested my modifications on a Windows 7 machine with the latest WinPcap and on Ubuntu (18.04) with LibPcap (1.8.1) and it worked fine for me.

It would be great, if you could have a look at my changes and maybe integrate them into the official SharpPcap development branch.

Please feel free to contact me anytime, in case of questions/doubts.

Cheers,
Manuel