### PR TITLE
Remove extra calls to GetAllNetworkInterfaces

### DIFF
--- a/SharpPcap/LibPcap/LibPcapLiveDevice.cs
+++ b/SharpPcap/LibPcap/LibPcapLiveDevice.cs
@@ -42,31 +42,6 @@ namespace SharpPcap.LibPcap
         public LibPcapLiveDevice( PcapInterface pcapIf )
         {
             m_pcapIf = pcapIf;
-
-            // go through the network interfaces and attempt to populate the mac address, 
-            // friendly name etc of this device
-            NetworkInterface[] nics = NetworkInterface.GetAllNetworkInterfaces();
-            foreach (NetworkInterface adapter in nics)
-            {
-                // if the name and id match then we have found the NetworkInterface
-                // that matches the PcapDevice
-                if (Name.EndsWith(adapter.Id))
-                {
-                    var ipProperties = adapter.GetIPProperties();
-                    int gatewayAddressCount = ipProperties.GatewayAddresses.Count;
-                    if (gatewayAddressCount != 0)
-                    {
-                        List<System.Net.IPAddress> gatewayAddresses = new List<System.Net.IPAddress>();
-                        foreach(GatewayIPAddressInformation gatewayInfo in ipProperties.GatewayAddresses) {
-                            gatewayAddresses.Add(gatewayInfo.Address);
-                        }
-                        Interface.GatewayAddresses = gatewayAddresses;
-                    }
-
-                    Interface.MacAddress = adapter.GetPhysicalAddress();
-                    Interface.FriendlyName = adapter.Name;
-                }
-            }
         }
 
         /// <summary>

--- a/SharpPcap/LibPcap/LibPcapLiveDeviceList.cs
+++ b/SharpPcap/LibPcap/LibPcapLiveDeviceList.cs
@@ -90,18 +90,11 @@ namespace SharpPcap.LibPcap
             if (result < 0)
                 throw new PcapException(errorBuffer.ToString());
 
-            IntPtr nextDevPtr = devicePtr;
-
-            while (nextDevPtr != IntPtr.Zero)
+            foreach (var pcap_if in PcapInterface.GetAllPcapInterfaces(devicePtr))
             {
-                // Marshal pointer into a struct
-                PcapUnmanagedStructures.pcap_if pcap_if_unmanaged =
-                    (PcapUnmanagedStructures.pcap_if)Marshal.PtrToStructure(nextDevPtr,
-                                                    typeof(PcapUnmanagedStructures.pcap_if));
-                PcapInterface pcap_if = new PcapInterface(pcap_if_unmanaged);
                 deviceList.Add(new LibPcapLiveDevice(pcap_if));
-                nextDevPtr = pcap_if_unmanaged.Next;
             }
+
             LibPcapSafeNativeMethods.pcap_freealldevs(devicePtr);  // Free unmanaged memory allocation.
 
             return deviceList;

--- a/SharpPcap/LibPcap/PcapInterface.cs
+++ b/SharpPcap/LibPcap/PcapInterface.cs
@@ -205,7 +205,7 @@ namespace SharpPcap.LibPcap
             return sb.ToString();
         }
 
-        static internal PcapInterface[] GetAllPcapInterfaces(IntPtr devicePtr)
+        static internal List<PcapInterface> GetAllPcapInterfaces(IntPtr devicePtr)
         {
             var list = new List<PcapInterface>();
             var nics = NetworkInterface.GetAllNetworkInterfaces();
@@ -229,7 +229,7 @@ namespace SharpPcap.LibPcap
                 nextDevPtr = pcap_if_unmanaged.Next;
             }
 
-            return list.ToArray();
+            return list;
         }
     }
 }

--- a/SharpPcap/LibPcap/PcapInterface.cs
+++ b/SharpPcap/LibPcap/PcapInterface.cs
@@ -25,6 +25,7 @@ using System.Text;
 using System.Runtime.InteropServices;
 using SharpPcap;
 using System.Net;
+using System.Net.NetworkInformation;
 
 namespace SharpPcap.LibPcap
 {
@@ -111,14 +112,33 @@ namespace SharpPcap.LibPcap
             }
         }
 
-        internal PcapInterface(PcapUnmanagedStructures.pcap_if pcapIf)
+        internal PcapInterface(PcapUnmanagedStructures.pcap_if pcapIf, NetworkInterface networkInterface)
         {
             Name = pcapIf.Name;
             Description = pcapIf.Description;
             Flags = pcapIf.Flags;
+            Addresses = new List<PcapAddress>();
+
+            // attempt to populate the mac address, 
+            // friendly name etc of this device
+            if (networkInterface != null)
+            {
+                var ipProperties = networkInterface.GetIPProperties();
+                int gatewayAddressCount = ipProperties.GatewayAddresses.Count;
+                if (gatewayAddressCount != 0)
+                {
+                    List<System.Net.IPAddress> gatewayAddresses = new List<System.Net.IPAddress>();
+                    foreach (GatewayIPAddressInformation gatewayInfo in ipProperties.GatewayAddresses)
+                    {
+                        gatewayAddresses.Add(gatewayInfo.Address);
+                    }
+                    GatewayAddresses = gatewayAddresses;
+                }
+                MacAddress = networkInterface.GetPhysicalAddress();
+                FriendlyName = networkInterface.Name;
+            }
 
             // retrieve addresses
-            Addresses = new List<PcapAddress>();
             IntPtr address = pcapIf.Addresses;
             while(address != IntPtr.Zero)
             {
@@ -183,6 +203,33 @@ namespace SharpPcap.LibPcap
             }
             sb.AppendFormat("Flags: {0}\n", Flags);
             return sb.ToString();
+        }
+
+        static internal PcapInterface[] GetAllPcapInterfaces(IntPtr devicePtr)
+        {
+            var list = new List<PcapInterface>();
+            var nics = NetworkInterface.GetAllNetworkInterfaces();
+            var nextDevPtr = devicePtr;
+            while (nextDevPtr != IntPtr.Zero)
+            {
+                // Marshal pointer into a struct
+                var pcap_if_unmanaged = Marshal.PtrToStructure<PcapUnmanagedStructures.pcap_if>(nextDevPtr);
+                NetworkInterface networkInterface = null;
+                foreach (var nic in nics)
+                {
+                    // if the name and id match then we have found the NetworkInterface
+                    // that matches the PcapDevice
+                    if (pcap_if_unmanaged.Name.EndsWith(nic.Id))
+                    {
+                        networkInterface = nic;
+                    }
+                }
+                var pcap_if = new PcapInterface(pcap_if_unmanaged, networkInterface);
+                list.Add(pcap_if);
+                nextDevPtr = pcap_if_unmanaged.Next;
+            }
+
+            return list.ToArray();
         }
     }
 }

--- a/SharpPcap/Npcap/NpcapDeviceList.cs
+++ b/SharpPcap/Npcap/NpcapDeviceList.cs
@@ -162,20 +162,10 @@ namespace SharpPcap.Npcap
         private static List<NpcapDevice> BuildDeviceList(IntPtr devicePtr)
         {
             var retval = new List<NpcapDevice>();
-            IntPtr nextDevPtr = devicePtr;
-
-            while (nextDevPtr != IntPtr.Zero)
+            foreach (var pcap_if in LibPcap.PcapInterface.GetAllPcapInterfaces(devicePtr))
             {
-                // Marshal pointer into a struct
-                var pcap_if_unmanaged =
-                    (LibPcap.PcapUnmanagedStructures.pcap_if)Marshal.PtrToStructure(nextDevPtr,
-                                                    typeof(LibPcap.PcapUnmanagedStructures.pcap_if));
-                LibPcap.PcapInterface pcap_if = new LibPcap.PcapInterface(pcap_if_unmanaged);
-
                 retval.Add(new NpcapDevice(pcap_if));
-                nextDevPtr = pcap_if_unmanaged.Next;
             }
-
             return retval;
         }
 

--- a/SharpPcap/WinPcap/WinPcapDeviceList.cs
+++ b/SharpPcap/WinPcap/WinPcapDeviceList.cs
@@ -163,20 +163,10 @@ namespace SharpPcap.WinPcap
         private static List<WinPcapDevice> BuildDeviceList(IntPtr devicePtr)
         {
             var retval = new List<WinPcapDevice>();
-            IntPtr nextDevPtr = devicePtr;
-
-            while (nextDevPtr != IntPtr.Zero)
+            foreach (var pcap_if in LibPcap.PcapInterface.GetAllPcapInterfaces(devicePtr))
             {
-                // Marshal pointer into a struct
-                var pcap_if_unmanaged =
-                    (LibPcap.PcapUnmanagedStructures.pcap_if)Marshal.PtrToStructure(nextDevPtr,
-                                                    typeof(LibPcap.PcapUnmanagedStructures.pcap_if));
-                LibPcap.PcapInterface pcap_if = new LibPcap.PcapInterface(pcap_if_unmanaged);
-
                 retval.Add(new WinPcapDevice(pcap_if));
-                nextDevPtr = pcap_if_unmanaged.Next;
             }
-
             return retval;
         }
 


### PR DESCRIPTION
# The Problem
* GetAllNetworkInterfaces is an expensive operation, it cab take up to few milliseconds.
With 10 adapters this function could take up to 200ms.

* The existing code calls GetAllNetworkInterfaces for each pcap device created, this causes a Refresh operation to take seconds (10 * 200ms).
* Calling the constructor of any pcap device implicitly calls GetAllNetworkInterfaces, causing a delay.

# Solution
* Proposed fix is to have GetAllNetworkInterfaces called once for each refresh operation.
* And creating Pcap device with constructor takes 0s (by simplifying the constructor)