### PR TITLE
Allow sending packet using Span<byte>

### DIFF
--- a/SharpPcap/ICaptureDevice.cs
+++ b/SharpPcap/ICaptureDevice.cs
@@ -215,6 +215,13 @@ namespace SharpPcap
         void SendPacket(byte[] p, int size);
 
         /// <summary>
+        /// Sends a raw packet throgh this device
+        /// </summary>
+        /// <param name="p">The packet bytes to send</param>
+        /// <param name="size">The number of bytes to send</param>
+        void SendPacket(ReadOnlySpan<byte> p);
+
+        /// <summary>
         /// Return the pcap link layer value of an adapter. 
         /// </summary>
         PacketDotNet.LinkLayers LinkType { get; }

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Unix.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Unix.cs
@@ -90,7 +90,7 @@ namespace SharpPcap.LibPcap
         /// <param name="size">the dimension of the buffer pointed by data</param>
         /// <returns>0 if the packet is succesfully sent, -1 otherwise.</returns>
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, IntPtr  data, int size);
+        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, in byte data, int size);
 
         /// <summary>
         /// Compile a packet filter, converting an high level filtering expression (see Filtering expression syntax) in a program that can be interpreted by the kernel-level filtering engine. 

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Windows.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Windows.cs
@@ -94,7 +94,7 @@ namespace SharpPcap.LibPcap
         /// <param name="size">the dimension of the buffer pointed by data</param>
         /// <returns>0 if the packet is succesfully sent, -1 otherwise.</returns>
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, IntPtr  data, int size);
+        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, in byte data, int size);
 
         /// <summary>
         /// Compile a packet filter, converting an high level filtering expression (see Filtering expression syntax) in a program that can be interpreted by the kernel-level filtering engine. 

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -132,7 +132,7 @@ namespace SharpPcap.LibPcap
         /// <param name="data">contains the data of the packet to send (including the various protocol headers)</param>
         /// <param name="size">the dimension of the buffer pointed by data</param>
         /// <returns>0 if the packet is succesfully sent, -1 otherwise.</returns>
-        internal static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, IntPtr  data, int size)
+        internal static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, in byte data, int size)
         {
             return UseWindows ? Windows.pcap_sendpacket(adaptHandle, data, size) : Unix.pcap_sendpacket(adaptHandle, data, size);
         }

--- a/SharpPcap/LibPcap/PcapDevice.cs
+++ b/SharpPcap/LibPcap/PcapDevice.cs
@@ -647,7 +647,22 @@ namespace SharpPcap.LibPcap
         /// <param name="size">The number of bytes to send</param>
         public virtual void SendPacket(byte[] p, int size)
         {
-            throw new System.NotImplementedException();
+            if (size > p.Length)
+            {
+                throw new ArgumentException("Invalid packetSize value: " + size +
+                "\nArgument size is larger than the total size of the packet.");
+            }
+            SendPacket(new ReadOnlySpan<byte>(p, 0, size));
+        }
+
+        /// <summary>
+        /// Sends a raw packet throgh this device
+        /// </summary>
+        /// <param name="p">The packet bytes to send</param>
+        /// <param name="size">The number of bytes to send</param>
+        public virtual void SendPacket(ReadOnlySpan<byte> p)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/SharpPcap/SharpPcap.csproj
+++ b/SharpPcap/SharpPcap.csproj
@@ -10,6 +10,7 @@
     <RepositoryUrl>https://github.com/chmorgan/sharppcap</RepositoryUrl>
     <Copyright>Tamir Gal, Chris Morgan and others</Copyright>
     <PackageLicenseUrl>https://github.com/chmorgan/sharppcap/blob/master/LICENSE</PackageLicenseUrl>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -22,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="PacketDotNet" Version="1.0.3" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Two main changes:
* Make SendPacket allocate no memory
* Allow using `Span<byte>` instead of byte[]
---
Zero copy PInvoke logic based on:
https://medium.com/@antao.almada/p-invoking-using-span-t-a398b86f95d3