### PR TITLE
Basic support for WinDivert driver

### DIFF
--- a/SharpPcap/PosixTimeval.cs
+++ b/SharpPcap/PosixTimeval.cs
@@ -242,6 +242,21 @@ namespace SharpPcap
         }
 
         /// <summary>
+        /// Construct a PosixTimeval with DateTime object
+        /// </summary>
+        /// <param name="time">
+        /// The DateTime object to use
+        /// </param>
+        public PosixTimeval(DateTime time)
+        {
+            DateTimeToUnixTimeVal(time.ToUniversalTime(),
+                                  out ulong seconds,
+                                  out ulong microseconds);
+
+            this.Seconds = seconds;
+            this.MicroSeconds = microseconds;
+        }
+        /// <summary>
         /// Construct a PosixTimeval using the current UTC time
         /// </summary>
         public PosixTimeval()

--- a/SharpPcap/WinDivert/WinDivertAddress.cs
+++ b/SharpPcap/WinDivert/WinDivertAddress.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace SharpPcap.WinDivert
+{
+    /// <summary>
+    /// The WinDivertAddress structure represents the "address" of a captured or injected packet. The
+    /// address includes the packet's timestamp, network interfaces, direction and other information.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct WinDivertAddress
+    {
+        public long Timestamp;
+        public byte Layer;
+        public byte Event;
+        public byte Flags;
+        public uint IfIdx;
+        public uint SubIfIdx;
+    }
+}

--- a/SharpPcap/WinDivert/WinDivertDevice.cs
+++ b/SharpPcap/WinDivert/WinDivertDevice.cs
@@ -1,0 +1,297 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
+using System.Threading;
+using PacketDotNet;
+
+namespace SharpPcap.WinDivert
+{
+    public class WinDivertDevice : ICaptureDevice
+    {
+
+        static readonly DateTime BootTime = DateTime.Now - TimeSpan.FromTicks(Stopwatch.GetTimestamp());
+
+        const int ERROR_INSUFFICIENT_BUFFER = 122;
+        const int ERROR_NO_DATA = 232;
+
+        protected IntPtr Handle;
+
+        public string Name => "WinDivert";
+
+        public string Description => "WinDivert Packet Driver";
+
+        public LinkLayers LinkType => LinkLayers.Raw;
+
+        public PhysicalAddress MacAddress => null;
+
+        public ICaptureStatistics Statistics => null;
+
+        public string LastError { get; private set; }
+
+        private string filter;
+        public string Filter
+        {
+            get
+            {
+                return string.IsNullOrEmpty(filter) ? "true" : filter;
+            }
+            set
+            {
+                var ret = WinDivertNative.WinDivertHelperCompileFilter(value, WinDivertLayer.Network, IntPtr.Zero, 0, out IntPtr errStrPtr, out uint errPos);
+                if (!ret)
+                {
+                    var errStr = Marshal.PtrToStringAnsi(errStrPtr);
+                    throw new PcapException($"Filter string is invalid at position {errPos}\n{errStr}");
+                }
+                filter = value;
+            }
+        }
+
+        public void Close()
+        {
+            if (Handle != IntPtr.Zero)
+            {
+                if (!WinDivertNative.WinDivertClose(Handle))
+                {
+                    ThrowLastWin32Error("Failed to close device");
+                }
+                Handle = IntPtr.Zero;
+            }
+        }
+
+        public RawCapture GetNextPacket()
+        {
+            ThrowIfNotOpen();
+            Span<byte> buffer = stackalloc byte[4096];
+            while (true)
+            {
+                bool ret;
+                WinDivertAddress addr;
+                uint readLen;
+                unsafe
+                {
+                    fixed (byte* p = buffer)
+                    {
+                        ret = WinDivertNative.WinDivertRecv(Handle, new IntPtr(p), (uint)buffer.Length, out readLen, out addr);
+                    }
+                }
+                if (!ret)
+                {
+                    var err = Marshal.GetLastWin32Error();
+                    if (err == ERROR_INSUFFICIENT_BUFFER)
+                    {
+                        // Increase buffer size
+                        buffer = stackalloc byte[buffer.Length * 2];
+                        continue;
+                    }
+                    if (err == ERROR_NO_DATA)
+                    {
+                        return null;
+                    }
+                    ThrowWin32Error("Recv failed", err);
+                }
+                var timestamp = new PosixTimeval(BootTime + TimeSpan.FromTicks(addr.Timestamp));
+                var data = buffer.Slice(0, (int)readLen).ToArray();
+                var raw = new RawCapture(LinkType, timestamp, data);
+                return raw;
+            }
+        }
+
+        public int GetNextPacketPointers(ref IntPtr header, ref IntPtr data)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Open()
+        {
+            var handle = WinDivertNative.WinDivertOpen(Filter, WinDivertLayer.Network, 0, 1);
+            if (handle == IntPtr.Zero || handle == new IntPtr(-1))
+            {
+                ThrowLastWin32Error("Failed to open");
+            }
+            Handle = handle;
+        }
+
+        public void Open(DeviceMode mode)
+        {
+            Open();
+        }
+
+        public void Open(DeviceMode mode, int read_timeout)
+        {
+            Open();
+        }
+
+        public void Open(DeviceMode mode, int read_timeout, uint kernel_buffer_size)
+        {
+            Open();
+            SetParam(WinDivertParam.QueueSize, kernel_buffer_size);
+        }
+
+        public void Open(DeviceMode mode, int read_timeout, MonitorMode monitor_mode)
+        {
+            Open(mode, read_timeout);
+        }
+
+        public void Open(DeviceMode mode, int read_timeout, MonitorMode monitor_mode, uint kernel_buffer_size)
+        {
+            Open(mode, read_timeout, kernel_buffer_size);
+        }
+
+        protected void ThrowIfNotOpen()
+        {
+            if (Handle == IntPtr.Zero)
+            {
+                throw new DeviceNotReadyException("Device not open");
+            }
+        }
+
+        public void SetParam(WinDivertParam param, ulong value)
+        {
+            ThrowIfNotOpen();
+            var ret = WinDivertNative.WinDivertSetParam(Handle, param, value);
+            if (!ret)
+            {
+                ThrowLastWin32Error("Failed to set param");
+            }
+        }
+
+        public ulong GetParam(WinDivertParam param)
+        {
+            ThrowIfNotOpen();
+            var ret = WinDivertNative.WinDivertGetParam(Handle, param, out ulong value);
+            if (!ret)
+            {
+                ThrowLastWin32Error("Failed to get param");
+            }
+            return value;
+        }
+
+        public void SendPacket(Packet p)
+        {
+            SendPacket(new ReadOnlySpan<byte>(p.Bytes));
+        }
+
+        public void SendPacket(Packet p, int size)
+        {
+            SendPacket(new ReadOnlySpan<byte>(p.Bytes, 0, size));
+        }
+
+        public void SendPacket(byte[] p)
+        {
+            SendPacket(new ReadOnlySpan<byte>(p));
+        }
+
+        public void SendPacket(byte[] p, int size)
+        {
+            SendPacket(new ReadOnlySpan<byte>(p, 0, size));
+        }
+
+        public void SendPacket(ReadOnlySpan<byte> p)
+        {
+            // TODO
+            throw new NotSupportedException();
+        }
+
+        public bool Started => captureThread?.IsAlive ?? false;
+
+        public TimeSpan StopCaptureTimeout { get; set; } = new TimeSpan(0, 0, 1);
+
+        public event PacketArrivalEventHandler OnPacketArrival;
+        public event CaptureStoppedEventHandler OnCaptureStopped;
+
+        /// <summary>
+        /// Thread that is performing the background packet capture
+        /// </summary>
+        protected Thread captureThread;
+        private CancellationTokenSource threadCancellationTokenSource = new CancellationTokenSource();
+
+        /// <summary>
+        /// Starts the capturing process via a background thread
+        /// OnPacketArrival() will be called for each captured packet
+        /// </summary>
+        public virtual void StartCapture()
+        {
+            if (!Started)
+            {
+                ThrowIfNotOpen();
+                if (OnPacketArrival == null)
+                {
+                    throw new DeviceNotReadyException("No delegates assigned to OnPacketArrival, no where for captured packets to go.");
+                }
+                var cancellationToken = threadCancellationTokenSource.Token;
+                captureThread = new Thread(() => this.CaptureThread(cancellationToken));
+                captureThread.Start();
+            }
+        }
+
+        protected void CaptureThread(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var packet = GetNextPacket();
+                    if (packet == null)
+                    {
+                        break;
+                    }
+                    OnPacketArrival?.Invoke(this, new CaptureEventArgs(packet, this));
+                }
+                OnCaptureStopped?.Invoke(this, CaptureStoppedEventStatus.CompletedWithoutError);
+            }
+            catch (Exception ex)
+            {
+                LastError = ex.Message;
+                OnCaptureStopped?.Invoke(this, CaptureStoppedEventStatus.ErrorWhileCapturing);
+            }
+        }
+
+        public virtual void Capture()
+        {
+            ThrowIfNotOpen();
+            CaptureThread(threadCancellationTokenSource.Token);
+        }
+
+        /// <summary>
+        /// Stops the capture process
+        ///
+        /// Throws an exception if the stop capture timeout is exceeded and the
+        /// capture thread was aborted
+        /// </summary>
+        public virtual void StopCapture()
+        {
+            if (Started)
+            {
+                threadCancellationTokenSource.Cancel();
+                threadCancellationTokenSource = new CancellationTokenSource();
+                if (!captureThread.Join(StopCaptureTimeout))
+                {
+                    try
+                    {
+                        captureThread.Abort();
+                    }
+                    catch (PlatformNotSupportedException)
+                    {
+                        // ignore
+                    }
+                }
+                captureThread = null; // otherwise we will always return true from PcapDevice.Started
+            }
+        }
+
+        private static void ThrowWin32Error(string message, int err)
+        {
+            var win32Message = new Win32Exception(err).Message;
+            throw new PcapException($"{message}\n{win32Message} (Error Code: {err})");
+        }
+
+        private static void ThrowLastWin32Error(string message)
+        {
+            var err = Marshal.GetLastWin32Error();
+            ThrowWin32Error(message, err);
+        }
+    }
+}

--- a/SharpPcap/WinDivert/WinDivertLayer.cs
+++ b/SharpPcap/WinDivert/WinDivertLayer.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * WinDivertLayer.cs
+ * (C) 2018, all rights reserved,
+ *
+ * This file is part of WinDivertSharp.
+ *
+ * WinDivertSharp is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * WinDivertSharp is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace SharpPcap.WinDivert
+{
+    /// <summary>
+    /// Represents which part of the networking layer a WinDivert handle is operating on.
+    /// </summary>
+    public enum WinDivertLayer : uint
+    {
+        /// <summary>
+        /// Represents the networking layer sans forwarded packets.
+        /// </summary>
+        Network = 0,
+
+        /// <summary>
+        /// Represents forwarded packets exclusively on the network layer.
+        /// </summary>
+        Forward = 1,
+        
+        Flow = 2,
+        Socket = 3,
+        Reflect = 4
+    }
+}

--- a/SharpPcap/WinDivert/WinDivertNative.cs
+++ b/SharpPcap/WinDivert/WinDivertNative.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace SharpPcap.WinDivert
+{
+    internal static unsafe class WinDivertNative
+    {
+        const string WINDIVERT_DLL = "WinDivert.dll";
+
+        [DllImport(WINDIVERT_DLL, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        internal static extern IntPtr WinDivertOpen([MarshalAs(UnmanagedType.LPStr)] string filter, WinDivertLayer layer, short priority, ulong flags);
+
+        [DllImport(WINDIVERT_DLL, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        internal static extern bool WinDivertRecv(IntPtr handle, IntPtr pPacket, uint packetLen, out uint readLen, out WinDivertAddress pAddr);
+
+        [DllImport(WINDIVERT_DLL, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        internal static extern bool WinDivertClose(IntPtr handle);
+
+        [DllImport(WINDIVERT_DLL, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        internal static extern bool WinDivertSetParam(IntPtr handle, WinDivertParam param, ulong value);
+
+        [DllImport(WINDIVERT_DLL, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        internal static extern bool WinDivertGetParam(IntPtr handle, WinDivertParam param, out ulong pValue);
+
+        [DllImport(WINDIVERT_DLL, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        internal static extern bool WinDivertHelperCompileFilter([MarshalAs(UnmanagedType.LPStr)] string filter, WinDivertLayer layer, IntPtr obj, uint objLen, out IntPtr errorStr, out uint errorPos);
+    }
+}

--- a/SharpPcap/WinDivert/WinDivertParam.cs
+++ b/SharpPcap/WinDivert/WinDivertParam.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace SharpPcap.WinDivert
+{
+    /// <summary>
+    /// Generic configuration params for an opened WinDivert handle.
+    /// </summary>
+    [Flags]
+    public enum WinDivertParam : uint
+    {
+        QueueLen = 0,
+        QueueTime = 1,
+        QueueSize = 2,
+    }
+}

--- a/Test/WinDivert/WinDivertDeviceTest.cs
+++ b/Test/WinDivert/WinDivertDeviceTest.cs
@@ -1,0 +1,107 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using PacketDotNet;
+using SharpPcap;
+using SharpPcap.WinDivert;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Text;
+using System.Threading;
+
+namespace Test.WinDivert
+{
+    [TestFixture]
+    [Platform("Win", Reason = "WinDivert driver is only available for Windows")]
+    public class WinDivertDeviceTest
+    {
+
+        /// <summary>
+        /// Modify PATH var to include our WinDivert DLL's so that the LoadLibrary function will
+        /// find whatever WinDivert dll required for the current architecture.
+        /// </summary>
+        [OneTimeSetUp]
+        public void InstallWinDivert()
+        {
+            var version = "2.2.0";
+            var arch = IntPtr.Size == 8 ? "x64" : "x86";
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            var driverPath = Path.Combine(baseDir, $"WinDivert-{version}-A\\" + arch);
+            // Download driver if not already there
+            if (!File.Exists(driverPath + "/WinDivert.dll"))
+            {
+                var zipFile = Path.Combine(baseDir, "windivert.zip");
+                using (var client = new WebClient())
+                {
+                    client.DownloadFile(
+                        $"https://github.com/basil00/Divert/releases/download/v{version}/WinDivert-{version}-A.zip",
+                        zipFile
+                    );
+                }
+                ZipFile.ExtractToDirectory(zipFile, baseDir);
+            }
+            // Patch PATH env
+            var oldPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            string newPath = oldPath + Path.PathSeparator + driverPath;
+            Environment.SetEnvironmentVariable("PATH", newPath);
+        }
+
+
+        [Test]
+        public void TestBadFilter()
+        {
+            var device = new WinDivertDevice();
+            var badFilter = "tcp.DstPort == 443 and foo";
+            Assert.Throws<PcapException>(() => device.Filter = badFilter);
+        }
+
+        [Test]
+        public void TestGetNextPacket()
+        {
+            var device = new WinDivertDevice
+            {
+                Filter = "!loopback and tcp"
+            };
+            device.Open();
+            var capture = device.GetNextPacket();
+            device.Close();
+            AssertTcp(capture);
+        }
+
+        [Test]
+        public void TestCapture()
+        {
+            var device = new WinDivertDevice
+            {
+                Filter = "!loopback and tcp"
+            };
+            device.Open();
+            var received = new List<RawCapture>();
+            device.OnPacketArrival += (s, e) =>
+            {
+                received.Add(e.Packet);
+            };
+            device.StartCapture();
+            Thread.Sleep(10000);
+            device.StopCapture();
+            device.Close();
+            Assert.That(received, Has.Count.AtLeast(2));
+            foreach (var capture in received)
+            {
+                AssertTcp(capture);
+            }
+        }
+
+        private void AssertTcp(RawCapture capture)
+        {
+            Assert.NotNull(capture);
+            var packet = Packet.ParsePacket(capture.LinkLayerType, capture.Data);
+            Assert.IsInstanceOf<RawIPPacket>(packet);
+            Assert.IsInstanceOf<IPPacket>(packet.PayloadPacket);
+            Assert.IsInstanceOf<TcpPacket>(packet.PayloadPacket.PayloadPacket);
+        }
+    }
+
+}


### PR DESCRIPTION
# About
WinDivert is a similar driver to WinPcap/Npcap but with a different objectives:
* Only works on network layer (no link layer support)
* Injects itself between the application and the OS, not between the OS and the adapter driver.
* Can cause the OS to drop packets
* Can cause the OS to delay/alter received/sent packets
* Portable (no installation required)

# This PR
This PR is NOT intended to support all of WinDivert features, instead it focuses on the ones that are common with Libpcap: the ability to sniff packets.

https://www.reqrypt.org/windivert.html