### PR TITLE
Make SendQueue cross platform

### DIFF
--- a/Examples/Example10.SendQueue/Example10.SendQueues.cs
+++ b/Examples/Example10.SendQueue/Example10.SendQueues.cs
@@ -2,6 +2,7 @@ using System;
 using SharpPcap;
 using SharpPcap.Npcap;
 using SharpPcap.LibPcap;
+using SendQueue = SharpPcap.Npcap.SendQueue;
 
 namespace Example10
 {

--- a/SharpPcap/LibPcap/LibPcapLiveDevice.cs
+++ b/SharpPcap/LibPcap/LibPcapLiveDevice.cs
@@ -313,9 +313,14 @@ namespace SharpPcap.LibPcap
             {
                 throw new ArgumentException("Packet length can't be larger than " + Pcap.MAX_PACKET_SIZE);
             }
-            var p_packet = MemoryMarshal.GetReference(p);
-            int res = LibPcapSafeNativeMethods.pcap_sendpacket(PcapHandle, p_packet, p.Length);
-
+            int res;
+            unsafe
+            {
+                fixed (byte* p_packet = p)
+                {
+                    res = LibPcapSafeNativeMethods.pcap_sendpacket(PcapHandle, new IntPtr(p_packet), p.Length);
+                }
+            }
             if (res < 0)
             {
                 throw new PcapException("Can't send packet: " + LastError);

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Unix.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Unix.cs
@@ -24,6 +24,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
+using static SharpPcap.LibPcap.PcapUnmanagedStructures;
 
 namespace SharpPcap.LibPcap
 {
@@ -89,7 +90,7 @@ namespace SharpPcap.LibPcap
         /// <param name="size">the dimension of the buffer pointed by data</param>
         /// <returns>0 if the packet is succesfully sent, -1 otherwise.</returns>
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, in byte data, int size);
+        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, IntPtr data, int size);
 
         /// <summary>
         /// Compile a packet filter, converting an high level filtering expression (see Filtering expression syntax) in a program that can be interpreted by the kernel-level filtering engine. 
@@ -261,6 +262,24 @@ namespace SharpPcap.LibPcap
         /// </returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_fileno(IntPtr /* pcap_t* p */ adapter);
+        #endregion
+
+        #region Send queue functions
+
+        /// <summary>
+        /// Send a queue of raw packets to the network. 
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="queue"></param>
+        /// <param name="sync">determines if the send operation must be synchronized: 
+        /// if it is non-zero, the packets are sent respecting the timestamps, 
+        /// otherwise they are sent as fast as possible</param>
+        /// <returns>The amount of bytes actually sent. 
+        /// If it is smaller than the size parameter, an error occurred 
+        /// during the send. The error can be caused by a driver/adapter 
+        /// problem or by an inconsistent/bogus send queue.</returns>
+        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_sendqueue_transmit(IntPtr/*pcap_t * */p, ref pcap_send_queue queue, int sync);
         #endregion
     }
 }

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Windows.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Windows.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
+using static SharpPcap.LibPcap.PcapUnmanagedStructures;
 
 namespace SharpPcap.LibPcap
 {
@@ -94,7 +95,7 @@ namespace SharpPcap.LibPcap
         /// <param name="size">the dimension of the buffer pointed by data</param>
         /// <returns>0 if the packet is succesfully sent, -1 otherwise.</returns>
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, in byte data, int size);
+        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, IntPtr data, int size);
 
         /// <summary>
         /// Compile a packet filter, converting an high level filtering expression (see Filtering expression syntax) in a program that can be interpreted by the kernel-level filtering engine. 
@@ -259,6 +260,24 @@ namespace SharpPcap.LibPcap
         /// </returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_fileno(IntPtr /* pcap_t* p */ adapter);
+        #endregion
+
+        #region Send queue functions
+
+        /// <summary>
+        /// Send a queue of raw packets to the network. 
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="queue"></param>
+        /// <param name="sync">determines if the send operation must be synchronized: 
+        /// if it is non-zero, the packets are sent respecting the timestamps, 
+        /// otherwise they are sent as fast as possible</param>
+        /// <returns>The amount of bytes actually sent. 
+        /// If it is smaller than the size parameter, an error occurred 
+        /// during the send. The error can be caused by a driver/adapter 
+        /// problem or by an inconsistent/bogus send queue.</returns>
+        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_sendqueue_transmit(IntPtr/*pcap_t * */p, ref pcap_send_queue queue, int sync);
         #endregion
     }
 }

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -24,6 +24,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
+using static SharpPcap.LibPcap.PcapUnmanagedStructures;
 
 namespace SharpPcap.LibPcap
 {
@@ -131,7 +132,7 @@ namespace SharpPcap.LibPcap
         /// <param name="data">contains the data of the packet to send (including the various protocol headers)</param>
         /// <param name="size">the dimension of the buffer pointed by data</param>
         /// <returns>0 if the packet is succesfully sent, -1 otherwise.</returns>
-        internal static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, in byte data, int size)
+        internal static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, IntPtr data, int size)
         {
             return UseWindows ? Windows.pcap_sendpacket(adaptHandle, data, size) : Unix.pcap_sendpacket(adaptHandle, data, size);
         }
@@ -361,6 +362,28 @@ namespace SharpPcap.LibPcap
         internal static int pcap_fileno(IntPtr /* pcap_t* p */ adapter)
         {
             return UseWindows ? Windows.pcap_fileno(adapter) : Unix.pcap_fileno(adapter);
+        }
+        #endregion
+
+        #region Send queue functions
+
+        /// <summary>
+        /// Send a queue of raw packets to the network. 
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="queue"></param>
+        /// <param name="sync">determines if the send operation must be synchronized: 
+        /// if it is non-zero, the packets are sent respecting the timestamps, 
+        /// otherwise they are sent as fast as possible</param>
+        /// <returns>The amount of bytes actually sent. 
+        /// If it is smaller than the size parameter, an error occurred 
+        /// during the send. The error can be caused by a driver/adapter 
+        /// problem or by an inconsistent/bogus send queue.</returns>
+        internal static int pcap_sendqueue_transmit(IntPtr/*pcap_t * */p, ref pcap_send_queue queue, int sync)
+        {
+            return UseWindows
+                ? Windows.pcap_sendqueue_transmit(p, ref queue, sync)
+                : Unix.pcap_sendqueue_transmit(p, ref queue, sync);
         }
         #endregion
     }

--- a/SharpPcap/LibPcap/PcapHeader.cs
+++ b/SharpPcap/LibPcap/PcapHeader.cs
@@ -35,6 +35,21 @@ namespace SharpPcap.LibPcap
 
         static readonly bool is32BitTs = IntPtr.Size == 4 || isWindows;
 
+        internal static int MemorySize = GetMemorySize();
+
+        private static int GetMemorySize()
+        {
+            if (isWindows)
+            {
+                return Marshal.SizeOf<PcapUnmanagedStructures.pcap_pkthdr_windows>();
+            }
+            if (isMacOSX)
+            {
+                return Marshal.SizeOf<PcapUnmanagedStructures.pcap_pkthdr_macosx>();
+            }
+            return Marshal.SizeOf<PcapUnmanagedStructures.pcap_pkthdr_unix>();
+        }
+
         /// <summary>
         ///  A wrapper class for libpcap's pcap_pkthdr structure
         /// </summary>

--- a/SharpPcap/LibPcap/SendQueue.cs
+++ b/SharpPcap/LibPcap/SendQueue.cs
@@ -1,0 +1,252 @@
+﻿/*
+This file is part of SharpPcap.
+
+SharpPcap is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SharpPcap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* 
+ * Copyright 2005 Tamir Gal <tamir@tamirgal.com>
+ * Copyright 2008-2009 Chris Morgan <chmorgan@gmail.com>
+ * Copyright 2008-2009 Phillip Lemon <lucidcomms@gmail.com>
+ */
+
+using PacketDotNet;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using static SharpPcap.LibPcap.PcapUnmanagedStructures;
+
+namespace SharpPcap.LibPcap
+{
+    public class SendQueue : IDisposable
+    {
+        public static readonly bool IsHardwareAccelerated = GetIsHardwareAccelerated();
+
+        private static bool GetIsHardwareAccelerated()
+        {
+            try
+            {
+                pcap_send_queue queue = default;
+                LibPcapSafeNativeMethods.pcap_sendqueue_transmit(IntPtr.Zero, ref queue, 0);
+                return true;
+            }
+            catch (TypeLoadException)
+            {
+                // Function pcap_sendqueue_transmit not found
+                return false;
+            }
+        }
+
+        private byte[] buffer;
+        public int CurrentLength { get; private set; }
+
+        public SendQueue(int memSize)
+        {
+            buffer = new byte[memSize];
+        }
+
+        /// <summary>
+        /// Add a packet to this send queue. The PcapHeader defines the packet length.
+        /// </summary>
+        /// <param name="header">The pcap header of the packet</param>
+        /// <param name="packet">The packet bytes to add</param>
+        /// <returns>True if success, else false</returns>
+        public bool Add(PcapHeader header, byte[] packet)
+        {
+            if (buffer == null)
+            {
+                throw new ObjectDisposedException(nameof(SendQueue));
+            }
+            var hdrSize = PcapHeader.MemorySize;
+            var pktSize = (int)header.CaptureLength;
+            // the header defines the size to send
+            if (pktSize > packet.Length)
+            {
+                var error = string.Format("pcapHdr.CaptureLength of {0} > packet.Length {1}",
+                                          pktSize, packet.Length);
+                throw new InvalidOperationException(error);
+            }
+
+            if (hdrSize + pktSize > buffer.Length - CurrentLength)
+            {
+                return false;
+            }
+            //Marshal header
+            IntPtr hdrPtr = header.MarshalToIntPtr();
+            Marshal.Copy(hdrPtr, buffer, CurrentLength, hdrSize);
+            Marshal.FreeHGlobal(hdrPtr);
+
+            Buffer.BlockCopy(packet, 0, buffer, CurrentLength + hdrSize, pktSize);
+
+            CurrentLength += hdrSize + pktSize;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Send a queue of raw packets to the network. 
+        /// </summary>
+        /// <param name="device">
+        /// The device on which to send the queue
+        /// A <see cref="PcapDevice"/>
+        /// </param>
+        /// <param name="synchronized">
+        /// Should the timestamps be respected
+        /// </param>
+        /// <returns>
+        /// A <see cref="int"/>
+        /// </returns>
+        public int Transmit(PcapDevice device, bool synchronized)
+        {
+            if (buffer == null)
+            {
+                throw new ObjectDisposedException(nameof(SendQueue));
+            }
+            if (!device.Opened)
+            {
+                throw new DeviceNotReadyException("Can't transmit queue, the pcap device is closed");
+            }
+            if (IsHardwareAccelerated)
+            {
+                return NativeTransmit(device, synchronized);
+            }
+            return ManagedTransmit(device, synchronized);
+        }
+
+        protected unsafe int ManagedTransmit(PcapDevice device, bool synchronized)
+        {
+            if (CurrentLength == 0)
+            {
+                return 0;
+            }
+            var position = 0;
+            var hdrSize = PcapHeader.MemorySize;
+            var sw = new Stopwatch();
+            fixed (byte* buf = buffer)
+            {
+                var bufPtr = new IntPtr(buf);
+                var firstTimestamp = TimeSpan.FromTicks(PcapHeader.FromPointer(bufPtr).Date.Ticks);
+                while (position < CurrentLength)
+                {
+                    // Extract packet from buffer
+                    var header = PcapHeader.FromPointer(bufPtr + position);
+                    var pktSize = (int)header.CaptureLength;
+                    var p = new ReadOnlySpan<byte>(buffer, position + hdrSize, pktSize);
+                    if (synchronized)
+                    {
+                        var timestamp = TimeSpan.FromTicks(header.Date.Ticks);
+                        while (sw.Elapsed < timestamp - firstTimestamp)
+                        {
+                            // Wait for packet time
+                        }
+                    }
+                    // Send the packet
+                    int res;
+                    unsafe
+                    {
+                        fixed (byte* p_packet = p)
+                        {
+                            res = LibPcapSafeNativeMethods.pcap_sendpacket(device.PcapHandle, new IntPtr(p_packet), p.Length);
+                        }
+                    }
+                    // Start Stopwatch after sending first packet
+                    sw.Start();
+                    if (res < 0)
+                    {
+                        break;
+                    }
+                    position += hdrSize + pktSize;
+                }
+            }
+            return position;
+        }
+
+        protected unsafe int NativeTransmit(PcapDevice device, bool synchronized)
+        {
+            int sync = synchronized ? 1 : 0;
+            fixed (byte* buf = buffer)
+            {
+                var pcap_queue = new pcap_send_queue
+                {
+                    maxlen = (uint)buffer.Length,
+                    len = (uint)CurrentLength,
+                    ptrBuff = new IntPtr(buf)
+                };
+                return LibPcapSafeNativeMethods.pcap_sendqueue_transmit(device.PcapHandle, ref pcap_queue, sync);
+            }
+        }
+
+        public void Dispose()
+        {
+            buffer = null;
+        }
+    }
+
+    public static class SendQueueExtensions
+    {
+        /// <summary>
+        /// Add a packet to this send queue. 
+        /// </summary>
+        /// <param name="packet">The packet bytes to add</param>
+        /// <returns>True if success, else false</returns>
+        public static bool Add(this SendQueue queue, byte[] packet)
+        {
+            var header = new PcapHeader
+            {
+                PacketLength = (uint)packet.Length,
+                CaptureLength = (uint)packet.Length
+            };
+            return queue.Add(header, packet);
+        }
+
+        /// <summary>
+        /// Add a packet to this send queue. 
+        /// </summary>
+        /// <param name="packet">The packet bytes to add</param>
+        /// <returns>True if success, else false</returns>
+        public static bool Add(this SendQueue queue, Packet packet)
+        {
+            return queue.Add(packet.Bytes);
+        }
+
+        /// <summary>
+        /// Add a packet to this send queue. 
+        /// </summary>
+        /// <param name="packet">The packet to add</param>
+        /// <returns>True if success, else false</returns>
+        public static bool Add(this SendQueue queue, RawCapture packet)
+        {
+            var data = packet.Data;
+            var timeval = packet.Timeval;
+            var header = new PcapHeader((uint)timeval.Seconds, (uint)timeval.MicroSeconds,
+                                        (uint)data.Length, (uint)data.Length);
+            return queue.Add(header, data);
+        }
+
+        /// <summary>
+        /// Add a packet to this send queue.
+        /// </summary>
+        /// <param name="packet">The packet to add</param>
+        /// <param name="seconds">The 'seconds' part of the packet's timestamp</param>
+        /// <param name="microseconds">The 'microseconds' part of the packet's timestamp</param>
+        /// <returns>True if success, else false</returns>
+        public static bool Add(this SendQueue queue, byte[] packet, int seconds, int microseconds)
+        {
+            var header = new PcapHeader((uint)seconds, (uint)microseconds,
+                                        (uint)packet.Length, (uint)packet.Length);
+
+            return queue.Add(header, packet);
+        }
+    }
+}

--- a/SharpPcap/Npcap/SendQueue.cs
+++ b/SharpPcap/Npcap/SendQueue.cs
@@ -21,7 +21,6 @@ along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 using System;
-using System.Runtime.InteropServices;
 using SharpPcap.LibPcap;
 
 namespace SharpPcap.Npcap
@@ -29,10 +28,9 @@ namespace SharpPcap.Npcap
     /// <summary>
     /// Interface to the Npcap send queue extension methods
     /// </summary>
-    public class SendQueue
+    [Obsolete("Obsolete. Use LibPcap namespace instead.")]
+    public class SendQueue : LibPcap.SendQueue
     {
-        readonly IntPtr m_queue = IntPtr.Zero;
-
         /// <summary>
         /// Creates and allocates a new SendQueue
         /// </summary>
@@ -40,61 +38,8 @@ namespace SharpPcap.Npcap
         /// The maximun amount of memory (in bytes) 
         /// to allocate for the queue</param>
         public SendQueue(int memSize)
+            : base(memSize)
         {
-            // ensure that we are running under npcap
-            NpcapDevice.ThrowIfNotNpcap();
-
-            m_queue = SafeNativeMethods.pcap_sendqueue_alloc(memSize);
-            if (m_queue == IntPtr.Zero)
-                throw new PcapException("Error creating PcapSendQueue");
-        }
-
-        /// <summary>
-        /// Add a packet to this send queue. The PcapHeader defines the packet length.
-        /// </summary>
-        /// <param name="packet">The packet bytes to add</param>
-        /// <param name="pcapHdr">The pcap header of the packet</param>
-        /// <returns>True if success, else false</returns>
-        internal bool AddInternal(byte[] packet, PcapHeader pcapHdr)
-        {
-            if (m_queue == IntPtr.Zero)
-            {
-                throw new PcapException("Can't add packet, this queue is disposed");
-            }
-
-            // the header defines the size to send
-            if (pcapHdr.CaptureLength > packet.Length)
-            {
-                var error = string.Format("pcapHdr.CaptureLength of {0} > packet.Length {1}",
-                                          pcapHdr.CaptureLength, packet.Length);
-                throw new InvalidOperationException(error);
-            }
-
-            //Marshal packet
-            IntPtr pktPtr;
-            pktPtr = Marshal.AllocHGlobal(packet.Length);
-            Marshal.Copy(packet, 0, pktPtr, packet.Length);
-
-            //Marshal header
-            IntPtr hdrPtr = pcapHdr.MarshalToIntPtr();
-
-            int res = SafeNativeMethods.pcap_sendqueue_queue(m_queue, hdrPtr, pktPtr);
-
-            Marshal.FreeHGlobal(pktPtr);
-            Marshal.FreeHGlobal(hdrPtr);
-
-            return (res != -1);
-        }
-
-        /// <summary>
-        /// Add a packet to this send queue. 
-        /// </summary>
-        /// <param name="packet">The packet bytes to add</param>
-        /// <param name="pcapHdr">The pcap header of the packet</param>
-        /// <returns>True if success, else false</returns>
-        internal bool Add(byte[] packet, PcapHeader pcapHdr)
-        {
-            return this.AddInternal(packet, pcapHdr);
         }
 
         /// <summary>
@@ -104,11 +49,7 @@ namespace SharpPcap.Npcap
         /// <returns>True if success, else false</returns>
         public bool Add(byte[] packet)
         {
-            PcapHeader hdr = new PcapHeader
-            {
-                CaptureLength = (uint)packet.Length
-            };
-            return this.AddInternal(packet, hdr);
+            return SendQueueExtensions.Add(this, packet);
         }
 
         /// <summary>
@@ -118,11 +59,7 @@ namespace SharpPcap.Npcap
         /// <returns>True if success, else false</returns>
         public bool Add(RawCapture packet)
         {
-            var data = packet.Data;
-            var timeval = packet.Timeval;
-            var header = new PcapHeader((uint)timeval.Seconds, (uint)timeval.MicroSeconds,
-                                        (uint)data.Length, (uint)data.Length);
-            return this.AddInternal(data, header);
+            return SendQueueExtensions.Add(this, packet);
         }
 
         /// <summary>
@@ -134,10 +71,7 @@ namespace SharpPcap.Npcap
         /// <returns>True if success, else false</returns>
         public bool Add(byte[] packet, int seconds, int microseconds)
         {
-            var header = new PcapHeader((uint)seconds, (uint)microseconds,
-                                        (uint)packet.Length, (uint)packet.Length);
-
-            return this.Add(packet, header);
+            return SendQueueExtensions.Add(this, packet, seconds, microseconds);
         }
 
         /// <summary>
@@ -155,45 +89,7 @@ namespace SharpPcap.Npcap
         /// </returns>
         public int Transmit(NpcapDevice device, SendQueueTransmitModes transmitMode)
         {
-            if (!device.Opened)
-                throw new DeviceNotReadyException("Can't transmit queue, the pcap device is closed");
-
-            if (m_queue == IntPtr.Zero)
-            {
-                throw new PcapException("Can't transmit queue, this queue is disposed");
-            }
-
-            int sync = (transmitMode == SendQueueTransmitModes.Synchronized) ? 1 : 0;
-            return SafeNativeMethods.pcap_sendqueue_transmit(device.PcapHandle, m_queue, sync);
-        }
-
-        /// <summary>
-        /// Destroy the send queue. 
-        /// </summary>
-        public void Dispose()
-        {
-            if (m_queue != IntPtr.Zero)
-            {
-                SafeNativeMethods.pcap_sendqueue_destroy(m_queue);
-            }
-        }
-
-        /// <summary>
-        /// The current length in bytes of this queue
-        /// </summary>
-        public int CurrentLength
-        {
-            get
-            {
-                if (m_queue == IntPtr.Zero)
-                {
-                    throw new PcapException("Can't perform operation, this queue is disposed");
-                }
-                PcapUnmanagedStructures.pcap_send_queue q =
-                    (PcapUnmanagedStructures.pcap_send_queue)Marshal.PtrToStructure
-                    (m_queue, typeof(PcapUnmanagedStructures.pcap_send_queue));
-                return (int)q.len;
-            }
+            return Transmit(device, transmitMode == SendQueueTransmitModes.Synchronized);
         }
     }
 }

--- a/SharpPcap/WinPcap/SafeNativeMethods.cs
+++ b/SharpPcap/WinPcap/SafeNativeMethods.cs
@@ -144,47 +144,6 @@ namespace SharpPcap.WinPcap
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_setmintocopy(IntPtr /* pcap_t */ adapter, int sizeInBytes);
 
-        #region Send queue functions
-        /// <summary>
-        /// Allocate a send queue. 
-        /// </summary>
-        /// <param name="memsize">The size of the queue</param>
-        /// <returns>A pointer to the allocated buffer</returns>
-        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /*pcap_send_queue * */pcap_sendqueue_alloc(int memsize);
-
-        /// <summary>
-        /// Destroy a send queue. 
-        /// </summary>
-        /// <param name="queue">A pointer to the queue start address</param>
-        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static void pcap_sendqueue_destroy(IntPtr /* pcap_send_queue * */queue);
-
-        /// <summary>
-        /// Add a packet to a send queue. 
-        /// </summary>
-        /// <param name="queue">A pointer to a queue</param>
-        /// <param name="header">The pcap header of the packet to send</param>
-        /// <param name="data">The packet data</param>
-        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_sendqueue_queue(IntPtr /* pcap_send_queue * */queue, IntPtr /* **pkt_header */ header, IntPtr data);
-
-        /// <summary>
-        /// Send a queue of raw packets to the network. 
-        /// </summary>
-        /// <param name="p"></param>
-        /// <param name="queue"></param>
-        /// <param name="sync">determines if the send operation must be synchronized: 
-        /// if it is non-zero, the packets are sent respecting the timestamps, 
-        /// otherwise they are sent as fast as possible</param>
-        /// <returns>The amount of bytes actually sent. 
-        /// If it is smaller than the size parameter, an error occurred 
-        /// during the send. The error can be caused by a driver/adapter 
-        /// problem or by an inconsistent/bogus send queue.</returns>
-        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_sendqueue_transmit(IntPtr/*pcap_t * */p, IntPtr /* pcap_send_queue * */queue, int sync);
-        #endregion
-
         #endregion
     }
 }

--- a/Test/SendPacketTest.cs
+++ b/Test/SendPacketTest.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using PacketDotNet;
+using SharpPcap;
+using SharpPcap.LibPcap;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Test.TestHelper;
+using static System.TimeSpan;
+
+namespace Test
+{
+    [TestFixture]
+    public class SendPacketTest
+    {
+        private const string Filter = "ether proto 0x1234";
+
+        [Test]
+        public void TestSendPacketTest()
+        {
+            var packet = EthernetPacket.RandomPacket();
+            packet.Type = (EthernetType)0x1234;
+            var received = RunCapture(Filter, (device) =>
+            {
+
+                device.SendPacket(packet);
+            });
+            Assert.That(received, Has.Count.EqualTo(1));
+            CollectionAssert.AreEquivalent(packet.Bytes, received[0].Data);
+        }
+    }
+}

--- a/Test/SendQueueTest.cs
+++ b/Test/SendQueueTest.cs
@@ -1,0 +1,125 @@
+﻿using NUnit.Framework;
+using PacketDotNet;
+using SharpPcap;
+using SharpPcap.LibPcap;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Test.TestHelper;
+using static System.TimeSpan;
+
+namespace Test
+{
+    [TestFixture]
+    public class SendQueueTest
+    {
+        private const string Filter = "ether proto 0x1234";
+        private const int PacketCount = 8;
+        private static readonly long DeltaTicks = FromMilliseconds(1).Ticks;
+
+        [Test]
+        public void TestNativeTransmitNormal()
+        {
+            var received = RunCapture(Filter, (device) =>
+            {
+                GetSendQueue().NativeTransmit(device, false);
+            });
+            AssertGoodTransmitNormal(received);
+        }
+
+        [Test]
+        public void TestNativeTransmitSync()
+        {
+            var received = RunCapture(Filter, (device) =>
+            {
+                GetSendQueue().NativeTransmit(device, true);
+            });
+            AssertGoodTransmitSync(received);
+        }
+
+        [Test]
+        public void TestManagedTransmitNormal()
+        {
+            var received = RunCapture(Filter, (device) =>
+            {
+                GetSendQueue().ManagedTransmit(device, false);
+            });
+            AssertGoodTransmitNormal(received);
+        }
+
+        [Test]
+        public void TestManagedTransmitSync()
+        {
+            var received = RunCapture(Filter, (device) =>
+            {
+                GetSendQueue().ManagedTransmit(device, true);
+            });
+            AssertGoodTransmitSync(received);
+        }
+
+        private static void AssertGoodTransmitNormal(List<RawCapture> received)
+        {
+            Assert.That(received, Has.Count.EqualTo(PacketCount));
+            var times = received.Select(r => r.Timeval.Date);
+            Assert.That(times.Max() - times.Min(), Is.LessThan(FromMilliseconds(1)));
+        }
+
+        private static void AssertGoodTransmitSync(List<RawCapture> received)
+        {
+            Assert.That(received, Has.Count.EqualTo(PacketCount));
+            var times = received.Select(r => r.Timeval.Date).ToArray();
+            for (int i = 1; i < PacketCount; i++)
+            {
+                var delta = (times[i] - times[i - 1]).Ticks;
+                Assert.That(delta, Is.LessThan(DeltaTicks * 1.1));
+                Assert.That(delta, Is.GreaterThan(DeltaTicks * 0.9));
+            }
+        }
+
+        [Test]
+        public void TestReturnValue()
+        {
+            var device = GetPcapDevice();
+            var queue = GetSendQueue();
+            var managed = queue.ManagedTransmit(device, false);
+            var native = queue.NativeTransmit(device, false);
+            Assert.AreEqual(managed, native);
+        }
+
+        /// <summary>
+        /// Helper method
+        /// </summary>
+        /// <returns></returns>
+        private static SendQueueWrapper GetSendQueue()
+        {
+            var queue = new SendQueueWrapper(1024);
+            var packet = EthernetPacket.RandomPacket();
+            packet.Type = (EthernetType)0x1234;
+            for (var i = 0; i < PacketCount; i++)
+            {
+                var time = i * DeltaTicks * 1e6 / TicksPerSecond;
+                Assert.IsTrue(queue.Add(packet.Bytes, 123456, (int)time));
+            }
+            return queue;
+        }
+
+        class SendQueueWrapper : SendQueue
+        {
+            public SendQueueWrapper(int memSize) : base(memSize)
+            {
+            }
+
+            internal new int NativeTransmit(PcapDevice device, bool synchronized)
+            {
+                return base.NativeTransmit(device, synchronized);
+            }
+
+            internal new int ManagedTransmit(PcapDevice device, bool synchronized)
+            {
+                return base.ManagedTransmit(device, synchronized);
+            }
+        }
+    }
+
+
+}

--- a/Test/TestHelper.cs
+++ b/Test/TestHelper.cs
@@ -1,4 +1,11 @@
-﻿using System.IO;
+﻿using PacketDotNet;
+using SharpPcap;
+using SharpPcap.LibPcap;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.NetworkInformation;
 using System.Reflection;
 
 namespace Test
@@ -9,6 +16,74 @@ namespace Test
         {
             var assembly = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             return Path.Combine(assembly, "capture_files", name);
+        }
+
+
+        /// <summary>
+        /// Find the first Ethernet adapter that is actually connected to something
+        /// </summary>
+        /// <returns></returns>
+        internal static PcapDevice GetPcapDevice()
+        {
+            var nics = NetworkInterface.GetAllNetworkInterfaces();
+            foreach (var device in LibPcapLiveDeviceList.Instance)
+            {
+                try
+                {
+                    device.Open();
+                    if (device.LinkType == LinkLayers.Ethernet)
+                    {
+                        var nic = nics.FirstOrDefault(ni => ni.Name == device.Interface.FriendlyName);
+                        if (nic.OperationalStatus == OperationalStatus.Up)
+                        {
+                            return device;
+                        }
+                    }
+                    device.Close();
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Run a test routine, and report what packets were captured during that routine
+        /// </summary>
+        /// <param name="filter">to avoid noise from OS affecting test result, a filter is needed</param>
+        /// <param name="routine">the routine to run</param>
+        /// <returns></returns>
+        internal static List<RawCapture> RunCapture(string filter, Action<PcapDevice> routine)
+        {
+            var device = GetPcapDevice();
+            if (device == null)
+            {
+                throw new InvalidOperationException("No ethernet pcap supported devices found, are you running" +
+                                                           " as a user with access to adapters (root on Linux)?");
+            }
+            Console.WriteLine($"Using device {device}");
+            var received = new List<RawCapture>();
+            device.Open();
+            device.Filter = filter;
+            void OnPacketArrival(object sender, CaptureEventArgs e)
+            {
+                received.Add(e.Packet);
+            }
+            device.OnPacketArrival += OnPacketArrival;
+            device.StartCapture();
+            try
+            {
+                routine(device);
+            }
+            finally
+            {
+                device.StopCapture();
+                device.OnPacketArrival -= OnPacketArrival;
+                device.Close();
+            }
+            return received;
         }
     }
 }


### PR DESCRIPTION
# Why?
After double checking, I found that the API related to send_queue is no longer windows specific,
Someone has already ported it to libpcap, although no documentation exists for it
https://github.com/the-tcpdump-group/libpcap/blob/master/pcap/pcap.h#L624

As a matter of fact, Windows no longer have any features specific only to it, the entire WinPcap API was merged to Libpcap, and Npcap only provides the driver now.

# Changes
This PR moves the send_queue logic to the common LibPcap namespace, with cross platform mechanisms to detect if the feature is available or not.
The existing public API has not been changed.

# Testing
I did not get the chance to test this on Linux/Mac hopefully the Unit Tests would show if there are problems.

@chmorgan how do I see the logs for Linux/Mac in Appveyor?

I added some tests for SendPacket as well, I noticed that the PR https://github.com/chmorgan/sharppcap/pull/93 may have made SendPacket unstable (some random failures). thus some minor tweaking to the marshaling was done.

