### PR TITLE
Fix duplicate MacAddress exception on Linux

### DIFF
--- a/SharpPcap/LibPcap/PcapInterface.cs
+++ b/SharpPcap/LibPcap/PcapInterface.cs
@@ -163,7 +163,7 @@ namespace SharpPcap.LibPcap
                     {
                         m_macAddress = newAddress;
                     }
-                    else
+                    else if (!MacAddress.Equals(newAddress.Addr.hardwareAddress))
                     {
                         throw new InvalidOperationException("found multiple hardware addresses, existing addr "
                                                                    + MacAddress.ToString() + ", new address " + newAddress.Addr.hardwareAddress.ToString());


### PR DESCRIPTION
On some linux machines, libpcap reports the same MacAddress more than once in the addresses list