### PR TITLE
Fix IsHardwareAccelerated in Npcap

### DIFF
--- a/SharpPcap/LibPcap/SendQueue.cs
+++ b/SharpPcap/LibPcap/SendQueue.cs
@@ -35,16 +35,22 @@ namespace SharpPcap.LibPcap
 
         private static bool GetIsHardwareAccelerated()
         {
+            var handle = LibPcapSafeNativeMethods.pcap_open_dead(1, 60);
             try
             {
+
                 pcap_send_queue queue = default;
-                LibPcapSafeNativeMethods.pcap_sendqueue_transmit(IntPtr.Zero, ref queue, 0);
+                LibPcapSafeNativeMethods.pcap_sendqueue_transmit(handle, ref queue, 0);
                 return true;
             }
             catch (TypeLoadException)
             {
                 // Function pcap_sendqueue_transmit not found
                 return false;
+            }
+            finally
+            {
+                LibPcapSafeNativeMethods.pcap_close(handle);
             }
         }
 

--- a/Test/SendQueueTest.cs
+++ b/Test/SendQueueTest.cs
@@ -86,6 +86,15 @@ namespace Test
             Assert.AreEqual(managed, native);
         }
 
+        [Test]
+        public void TestIsHardwareAccelerated()
+        {
+            Assert.AreEqual(
+                SendQueue.IsHardwareAccelerated,
+                Environment.OSVersion.Platform == PlatformID.Win32NT
+            );
+        }
+
         /// <summary>
         /// Helper method
         /// </summary>


### PR DESCRIPTION
Using a `IntPtr.Zero` as a device handle is acceptable in winpcap with send queue, Npcap throws a memory access violation.