### PR TITLE
Codecov: Tolerate one CI being down

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,5 @@ codecov:
     # 1 for circleci
     # 2 for travis
     # Total = 10
-    after_n_builds: 10
+    # Tolerate one of the services being down (worst case appveyor)
+    after_n_builds: 6


### PR DESCRIPTION
When one CI service fails for a PR, the coverage comment by Codecov should still show up