### PR TITLE
Fix SendPacket tests in Linux

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,7 @@ for:
   build_script:
     - dotnet build -c Release
   test_script:
-    - bash scripts/test.sh --filter TestCategory!=RemotePcap
+    - bash scripts/test.sh --filter "TestCategory!=RemotePcap&TestCategory!=WinDivert"
 
 -
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,7 +47,7 @@ for:
   install:
     - sudo -E bash scripts/install-libpcap.sh
   test_script:
-    - sudo -E bash scripts/test.sh --filter "TestCategory!=Performance&TestCategory!=SendPacket"
+    - sudo -E bash scripts/test.sh
 
 -
   matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run: sudo -E bash scripts/install-dotnet.sh
       - run: sudo -E bash scripts/install-libpcap.sh
-      - run: sudo -E bash scripts/test.sh --filter TestCategory!=SendPacket
+      - run: sudo -E bash scripts/test.sh
       - store_test_results:
           path: Test/TestResults
 

--- a/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
@@ -120,8 +120,6 @@ namespace SharpPcap.LibPcap
                 throw new NotSupportedOnCaptureFileException("Statistics not supported on a capture file");
             }
         }
-
-        protected internal override bool UsePosixPoll => false;
     }
 }
 

--- a/SharpPcap/LibPcap/LibPcapLiveDevice.cs
+++ b/SharpPcap/LibPcap/LibPcapLiveDevice.cs
@@ -270,6 +270,11 @@ namespace SharpPcap.LibPcap
                     throw new PcapException(err);
                 }
                 Active = true;
+                // retrieve the file descriptor of the adapter for use with poll()
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    FileDescriptor = LibPcapSafeNativeMethods.pcap_get_selectable_fd(PcapHandle);
+                }
             }
         }
 

--- a/SharpPcap/LibPcap/PcapDevice.cs
+++ b/SharpPcap/LibPcap/PcapDevice.cs
@@ -114,10 +114,16 @@ namespace SharpPcap.LibPcap
         }
 
         /// <summary>
+        /// The file descriptor obtained from pcap_fileno
+        /// Used for polling
+        /// </summary>
+        protected internal int FileDescriptor = -1;
+
+        /// <summary>
         /// The underlying pcap device handle
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public virtual IntPtr PcapHandle
+        public IntPtr PcapHandle
         {
             get { return m_pcapAdapterHandle; }
             set
@@ -403,9 +409,15 @@ namespace SharpPcap.LibPcap
                 throw new InvalidOperationDuringBackgroundCaptureException("GetNextPacket() invalid during background capture");
             }
 
+            p = null;
+
+            if (!PollFileDescriptor())
+            {
+                // We checked, there is no data using poll()
+                return 0;
+            }
             //Get a packet from npcap
             res = LibPcapSafeNativeMethods.pcap_next_ex(PcapHandle, ref header, ref data);
-            p = null;
 
             if (res > 0)
             {

--- a/TODO-CI.md
+++ b/TODO-CI.md
@@ -6,7 +6,7 @@ linux can't send packets
 at least when you make StartCapture on the same adapter nothing is received
 possibly related to https://github.com/the-tcpdump-group/libpcap/issues/400
 
-tests for linux have to run using `--filter TestCategory!=SendPacket`
+tests for linux require different device instances for sending and capturing
 
 ## Npcap & rpcapd
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
     vmImage: 'ubuntu-18.04'
   steps:
   - script: sudo -E bash scripts/install-libpcap.sh
-  - script: sudo -E bash scripts/test.sh --filter "TestCategory!=Performance&TestCategory!=SendPacket"
+  - script: sudo -E bash scripts/test.sh
 
 - job: macos
   pool:
@@ -26,7 +26,7 @@ jobs:
   steps:
   - script: sudo -E bash scripts/install-libpcap.sh
   - script: sudo sysctl -w net.inet.udp.maxdgram=65535
-  - script: sudo -E bash scripts/test.sh --filter TestCategory!=Performance
+  - script: sudo -E bash scripts/test.sh
 
 - job: windows_2016_vs2017_winpcap
   pool:

--- a/scripts/test-travis.sh
+++ b/scripts/test-travis.sh
@@ -10,5 +10,5 @@ fi
 # Test on linux
 if [ "$TRAVIS_OS_NAME" = "linux" ]
 then
-    sudo -E bash scripts/test.sh --filter TestCategory!=SendPacket
+    sudo -E bash scripts/test.sh
 fi


### PR DESCRIPTION
* Add polling before calling `pcap_next_ex` in Unix to prevent hanging
* Enable SendPacket tests in CI for all platforms