### PR TITLE
Add support for sending with WinDivert

### DIFF
--- a/SharpPcap/RawCapture.cs
+++ b/SharpPcap/RawCapture.cs
@@ -53,6 +53,15 @@ namespace SharpPcap
         public byte[] Data;
 
         /// <summary>
+        /// Creates a Packet object from the LinkLayerType and Data
+        /// </summary>
+        /// <returns></returns>
+        public virtual Packet GetPacket()
+        {
+            return Packet.ParsePacket(LinkLayerType, Data);
+        }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="LinkLayerType">

--- a/SharpPcap/WinDivert/IpHelper.cs
+++ b/SharpPcap/WinDivert/IpHelper.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+namespace SharpPcap.WinDivert
+{
+    /// <summary>
+    /// Helper methods to facilitate finding interface index from IP addresses
+    /// </summary>
+    public static class IpHelper
+    {
+        private const string IPHLPAPI = "iphlpapi.dll";
+
+        [DllImport(IPHLPAPI)]
+        private extern static uint GetBestInterfaceEx(byte[] ipAddress, out int index);
+
+        /// <summary>
+        /// This routine converts an IPAddress into a byte array that represents the
+        /// underlying sockaddr structure.
+        /// </summary>
+        /// <param name="address">IPAddress to convert to a binary form</param>
+        /// <returns>Binary array of the serialized socket address structure</returns>
+        private static byte[] GetSocketAddressBytes(IPAddress ip)
+        {
+            var address = new IPEndPoint(ip, 0).Serialize();
+            byte[] bytes;
+            bytes = new byte[address.Size];
+            for (int i = 0; i < address.Size; i++)
+            {
+                bytes[i] = address[i];
+            }
+            return bytes;
+        }
+
+        /// <summary>
+        /// wrapper around iphlpapi GetBestInterfaceEx,
+        /// Allows finding the appropriate interface index from the destination ip address
+        /// </summary>
+        /// <param name="destinationAddress"></param>
+        /// <returns></returns>
+        public static int GetBestInterfaceIndex(IPAddress destinationAddress)
+        {
+            var addr = GetSocketAddressBytes(destinationAddress);
+            int error = (int)GetBestInterfaceEx(addr, out int index);
+            if (error != 0)
+            {
+                throw new NetworkInformationException(error);
+            }
+            return index;
+        }
+
+        /// <summary>
+        /// Helper method to find the NetworkInterface that should be used for a given destination address
+        /// </summary>
+        /// <param name="destinationAddress"></param>
+        /// <returns></returns>
+        public static NetworkInterface GetBestInterface(IPAddress destinationAddress)
+        {
+            var interfaceIndex = GetBestInterfaceIndex(destinationAddress);
+
+            foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                var ipProperties = networkInterface.GetIPProperties();
+
+                if (networkInterface.Supports(NetworkInterfaceComponent.IPv4))
+                {
+                    var iPv4Properties = ipProperties.GetIPv4Properties();
+                    if (iPv4Properties?.Index == interfaceIndex)
+                    {
+                        return networkInterface;
+                    }
+                }
+
+                if (networkInterface.Supports(NetworkInterfaceComponent.IPv6))
+                {
+                    var iPv6Properties = ipProperties.GetIPv6Properties();
+                    if (iPv6Properties?.Index == interfaceIndex)
+                    {
+                        return networkInterface;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        [DllImport(IPHLPAPI)]
+        private static extern int GetBestRoute2(
+            IntPtr interfaceLuid,
+            int interfaceIndex,
+            byte[] sourceAddress,
+            byte[] destinationAddress,
+            uint addressSortOptions,
+            [In, Out] byte[] bestRoute,
+            [In, Out] byte[] bestSourceAddress
+        );
+
+        /// <summary>
+        /// We try to see if the addresses on a  given interface represent an inbound or outbound packet
+        /// Simply we try to find a route from src to dst, if one is found, then it's outbound
+        /// </summary>
+        /// <param name="interfaceIndex"></param>
+        /// <param name="srcAddr"></param>
+        /// <param name="dstAddr"></param>
+        /// <returns></returns>
+        internal static bool IsOutbound(int interfaceIndex, IPAddress srcAddr, IPAddress dstAddr)
+        {
+            var src = GetSocketAddressBytes(srcAddr);
+            var dst = GetSocketAddressBytes(dstAddr);
+            var best = new byte[src.Length];
+            const int routeSize = 103; // sizeof(MIB_IPFORWARD_ROW2)
+            var route = new byte[routeSize];
+            var ret = GetBestRoute2(default, interfaceIndex, src, dst, 0, route, best);
+            return ret == 0;
+        }
+    }
+}

--- a/SharpPcap/WinDivert/WinDivertAddress.cs
+++ b/SharpPcap/WinDivert/WinDivertAddress.cs
@@ -8,12 +8,12 @@ namespace SharpPcap.WinDivert
     /// address includes the packet's timestamp, network interfaces, direction and other information.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct WinDivertAddress
+    struct WinDivertAddress
     {
         public long Timestamp;
         public byte Layer;
         public byte Event;
-        public byte Flags;
+        public WinDivertPacketFlags Flags;
         public uint IfIdx;
         public uint SubIfIdx;
     }

--- a/SharpPcap/WinDivert/WinDivertCapture.cs
+++ b/SharpPcap/WinDivert/WinDivertCapture.cs
@@ -1,0 +1,36 @@
+﻿using PacketDotNet;
+using PacketDotNet.Utils;
+using System;
+
+namespace SharpPcap.WinDivert
+{
+    /// <summary>
+    /// Same as RawCapture, but with extra information from the WinDivert driver
+    /// </summary>
+    public class WinDivertCapture : RawCapture
+    {
+
+        public uint InterfaceIndex { get; set; }
+        public uint SubInterfaceIndex { get; set; }
+        public WinDivertPacketFlags Flags { get; set; }
+
+        public WinDivertCapture(PosixTimeval timeval, byte[] data) 
+            : base(LinkLayers.Raw, timeval, data)
+        {
+        }
+
+        /// <summary>
+        /// Creates a WinDivertPacket from current capture information
+        /// </summary>
+        /// <returns></returns>
+        public override Packet GetPacket()
+        {
+            return new WinDivertPacket(new ByteArraySegment(Data))
+            {
+                InterfaceIndex = InterfaceIndex,
+                SubInterfaceIndex = SubInterfaceIndex,
+                Flags = Flags,
+            };
+        }
+    }
+}

--- a/SharpPcap/WinDivert/WinDivertNative.cs
+++ b/SharpPcap/WinDivert/WinDivertNative.cs
@@ -25,5 +25,8 @@ namespace SharpPcap.WinDivert
 
         [DllImport(WINDIVERT_DLL, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         internal static extern bool WinDivertHelperCompileFilter([MarshalAs(UnmanagedType.LPStr)] string filter, WinDivertLayer layer, IntPtr obj, uint objLen, out IntPtr errorStr, out uint errorPos);
+
+        [DllImport(WINDIVERT_DLL, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        internal static extern bool WinDivertSend(IntPtr handle, IntPtr pPacket, uint packetLen, out uint pSendLen, ref WinDivertAddress pAddr);
     }
 }

--- a/SharpPcap/WinDivert/WinDivertPacket.cs
+++ b/SharpPcap/WinDivert/WinDivertPacket.cs
@@ -1,0 +1,27 @@
+﻿using PacketDotNet;
+using PacketDotNet.Utils;
+using System;
+
+namespace SharpPcap.WinDivert
+{
+    /// <summary>
+    /// Same as RawIPPacket, but allow specifying WinDivert metadata such as interface id
+    /// </summary>
+    public class WinDivertPacket : RawIPPacket
+    {
+        public uint InterfaceIndex { get; set; }
+        public uint SubInterfaceIndex { get; set; }
+        public WinDivertPacketFlags Flags { get; set; }
+
+        /// Constructor
+        /// </summary>
+        /// <param name="byteArraySegment">
+        /// A <see cref="ByteArraySegment" />
+        /// </param>
+        public WinDivertPacket(ByteArraySegment byteArraySegment)
+            : base(byteArraySegment)
+        {
+        }
+
+    }
+}

--- a/SharpPcap/WinDivert/WinDivertPacketFlags.cs
+++ b/SharpPcap/WinDivert/WinDivertPacketFlags.cs
@@ -1,0 +1,14 @@
+﻿namespace SharpPcap.WinDivert
+{
+    public enum WinDivertPacketFlags : byte
+    {
+        Sniffed = 1 << 0,
+        Outbound = 1 << 1,
+        Loopback = 1 << 2,
+        Impostor = 1 << 3,
+        IPv6 = 1 << 4,
+        IPChecksum = 1 << 5,
+        TCPChecksum = 1 << 6,
+        UDPChecksum = 1 << 7,
+    }
+}


### PR DESCRIPTION
Allow sending Packets using WinDivert

# Open Points
### Sub-Interface
@basil00 Could you provide an example/reference how one may be able to find the value of sub-interface ?
All the examples I found mention an interface index, but never a sub-interface index.
Example https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getbestinterface

### Inbound Packet
The test I made was only for outbound packets, and I verified packets were actually sent using Wireshark
@Zeelize could you use the code in the PR and see if it works correctly for your use case in #140? 