### PR TITLE
Use Libpcap 1.9.1 instead of master

### DIFF
--- a/scripts/install-libpcap.sh
+++ b/scripts/install-libpcap.sh
@@ -17,12 +17,10 @@ fi
 # clone into tmp folder
 rm -rf /tmp/install-libpcap
 
-git clone --depth 1 https://github.com/the-tcpdump-group/libpcap.git /tmp/install-libpcap
+# 1.9.1 is the version we tested to work
+git clone --depth 1 -b libpcap-1.9.1 https://github.com/the-tcpdump-group/libpcap.git /tmp/install-libpcap
 
 pushd /tmp/install-libpcap
-
-# 1.9.1 is the version we tested to work
-git checkout libpcap-1.9.1
 
 # remote is disabled by default, so we need to enable it
 ./configure --enable-remote

--- a/scripts/install-libpcap.sh
+++ b/scripts/install-libpcap.sh
@@ -23,7 +23,7 @@ git clone --depth 1 -b libpcap-1.9.1 https://github.com/the-tcpdump-group/libpca
 pushd /tmp/install-libpcap
 
 # remote is disabled by default, so we need to enable it
-./configure --enable-remote
+./configure --enable-remote --without-gcc
 
 # install the library
 make install

--- a/scripts/install-libpcap.sh
+++ b/scripts/install-libpcap.sh
@@ -23,7 +23,7 @@ git clone --depth 1 -b libpcap-1.9.1 https://github.com/the-tcpdump-group/libpca
 pushd /tmp/install-libpcap
 
 # remote is disabled by default, so we need to enable it
-./configure --enable-remote --without-gcc
+./configure --enable-remote --disable-universal
 
 # install the library
 make install


### PR DESCRIPTION
There was an error in the install script, and it seems it was using master version of Libpcap instead 1.9.1