### PR TITLE
Upgrade to .Net Core 3.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,7 @@ for:
     only:
       - image: Visual Studio 2017
   install:
+    - choco install -y dotnetcore-sdk --version=3.1.301
     - choco install -y winpcap
   build_script:
     - dotnet build -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: csharp
-dotnet: 2.2.105
+dotnet: 3.1.301
 
 matrix:
     include:

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <CoverletOutputFormat>opencover</CoverletOutputFormat>
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
 
 - job: macos
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - script: sudo -E bash scripts/install-libpcap.sh
   - script: sudo sysctl -w net.inet.udp.maxdgram=65535

--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -8,4 +8,4 @@ dpkg -i packages-microsoft-prod.deb
 apt-get update
 
 # Install DotNet
-apt-get install -y dotnet-sdk-2.2
+apt-get install -y dotnet-sdk-3.1


### PR DESCRIPTION
 .Net Core 2.2 reached end of life.

See https://devblogs.microsoft.com/dotnet/net-core-2-2-will-reach-end-of-life-on-december-23-2019/
