### PR TITLE
Make devices IDisposable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
    <Deterministic>true</Deterministic>
    <DebugType>full</DebugType>
    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+   <LangVersion>8.0</LangVersion>
  </PropertyGroup>
 </Project>

--- a/Examples/CreatingCaptureFile/CreatingCaptureFile.csproj
+++ b/Examples/CreatingCaptureFile/CreatingCaptureFile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/CreatingCaptureFile/Program.cs
+++ b/Examples/CreatingCaptureFile/Program.cs
@@ -47,7 +47,7 @@ namespace CreatingCaptureFile
             Console.Write("-- Please enter the output file name: ");
             string capFile = Console.ReadLine();
 
-            var device = devices[i];
+            using var device = devices[i];
 
             // Register our handler function to the 'packet arrival' event
             device.OnPacketArrival +=
@@ -91,9 +91,6 @@ namespace CreatingCaptureFile
 
             // Print out the device statistics
             Console.WriteLine(device.Statistics.ToString());
-
-            // Close the pcap device
-            device.Close();
         }
 
         private static int packetIndex = 0;

--- a/Examples/Example1.IfList/Example01.IfList.csproj
+++ b/Examples/Example1.IfList/Example01.IfList.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example10.SendQueue/Example10.SendQueue.csproj
+++ b/Examples/Example10.SendQueue/Example10.SendQueue.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example11.Statistics/Example11.Statistics.cs
+++ b/Examples/Example11.Statistics/Example11.Statistics.cs
@@ -53,7 +53,7 @@ namespace Example11
             Console.Write("-- Please choose a device to gather statistics on: ");
             i = int.Parse(Console.ReadLine());
 
-            var device = devices[i] as SharpPcap.Npcap.NpcapDevice;
+            using var device = devices[i] as SharpPcap.Npcap.NpcapDevice;
 
             // Register our handler function to the 'pcap statistics' event
             device.OnPcapStatistics +=
@@ -84,8 +84,6 @@ namespace Example11
             // Print out the device statistics
             Console.WriteLine(device.Statistics.ToString());
 
-            // Close the pcap device
-            device.Close();
             Console.WriteLine("Capture stopped, device closed.");
             Console.Write("Hit 'Enter' to exit...");
             Console.ReadLine();

--- a/Examples/Example11.Statistics/Example11.Statistics.csproj
+++ b/Examples/Example11.Statistics/Example11.Statistics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example12.PacketManipulation/Example12.PacketManipulation.csproj
+++ b/Examples/Example12.PacketManipulation/Example12.PacketManipulation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example2.ArpResolve/Example02.ArpResolve.csproj
+++ b/Examples/Example2.ArpResolve/Example02.ArpResolve.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example3.BasicCap/Example03.BasicCap.csproj
+++ b/Examples/Example3.BasicCap/Example03.BasicCap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example3.BasicCap/Program.cs
+++ b/Examples/Example3.BasicCap/Program.cs
@@ -45,7 +45,7 @@ namespace Example3
             Console.Write("-- Please choose a device to capture: ");
             i = int.Parse(Console.ReadLine());
 
-            var device = devices[i];
+            using var device = devices[i];
 
             // Register our handler function to the 'packet arrival' event
             device.OnPacketArrival +=
@@ -85,9 +85,6 @@ namespace Example3
 
             // Print out the device statistics
             Console.WriteLine(device.Statistics.ToString());
-
-            // Close the pcap device
-            device.Close();
         }
 
         /// <summary>

--- a/Examples/Example4.BasicCapNoCallback/Example04.BasicCapNoCallback.csproj
+++ b/Examples/Example4.BasicCapNoCallback/Example04.BasicCapNoCallback.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example4.BasicCapNoCallback/Example4.BasicCapNoCallback.cs
+++ b/Examples/Example4.BasicCapNoCallback/Example4.BasicCapNoCallback.cs
@@ -42,7 +42,7 @@ namespace Example4
             Console.Write("-- Please choose a device to capture: ");
             i = int.Parse(Console.ReadLine());
 
-            var device = devices[i];
+            using var device = devices[i];
 
             // Open the device for capturing
             int readTimeoutMilliseconds = 1000;
@@ -67,8 +67,6 @@ namespace Example4
             // Print out the device statistics
             Console.WriteLine(device.Statistics.ToString());
 
-            //Close the pcap device
-            device.Close();
             Console.WriteLine("-- Timeout elapsed, capture stopped, device closed.");
             Console.Write("Hit 'Enter' to exit...");
             Console.ReadLine();

--- a/Examples/Example5.PcapFilter/Example05.PcapFilter.csproj
+++ b/Examples/Example5.PcapFilter/Example05.PcapFilter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example5.PcapFilter/Program.cs
+++ b/Examples/Example5.PcapFilter/Program.cs
@@ -38,7 +38,7 @@ namespace Example5
             Console.Write("-- Please choose a device to capture: ");
             i = int.Parse(Console.ReadLine());
 
-            var device = devices[i];
+            using var device = devices[i];
 
             //Register our handler function to the 'packet arrival' event
             device.OnPacketArrival +=
@@ -63,10 +63,6 @@ namespace Example5
             // Start capture packets
             device.Capture();
 
-            // Close the pcap device
-            // (Note: this line will never be called since
-            //  we're capturing infinite number of packets
-            device.Close();
         }
 
         /// <summary>

--- a/Examples/Example6.DumpTCP/Example06.DumpTCP.csproj
+++ b/Examples/Example6.DumpTCP/Example06.DumpTCP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example6.DumpTCP/Program.cs
+++ b/Examples/Example6.DumpTCP/Program.cs
@@ -40,7 +40,7 @@ namespace Example6
             Console.Write("-- Please choose a device to capture: ");
             i = int.Parse(Console.ReadLine());
 
-            var device = devices[i];
+            using var device = devices[i];
 
             //Register our handler function to the 'packet arrival' event
             device.OnPacketArrival +=
@@ -65,10 +65,6 @@ namespace Example6
             // Start capture 'INFINTE' number of packets
             device.Capture();
 
-            // Close the pcap device
-            // (Note: this line will never be called since
-            //  we're capturing infinite number of packets
-            device.Close();
         }
 
         /// <summary>

--- a/Examples/Example9.SendPacket/Example09.SendPacket.csproj
+++ b/Examples/Example9.SendPacket/Example09.SendPacket.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/Example9.SendPacket/Example9.SendPacket.cs
+++ b/Examples/Example9.SendPacket/Example9.SendPacket.cs
@@ -38,7 +38,7 @@ namespace Example9
             Console.Write("-- Please choose a device to send a packet on: ");
             i = int.Parse(Console.ReadLine());
 
-            var device = devices[i];
+            using var device = devices[i];
 
             Console.Write("-- This will send a random packet out this interface, " +
                 "continue? [YES|no]");
@@ -68,9 +68,6 @@ namespace Example9
                 Console.WriteLine("-- " + e.Message);
             }
 
-            //Close the pcap device
-            device.Close();
-            Console.WriteLine("-- Device closed.");
             Console.Write("Hit 'Enter' to exit...");
             Console.ReadLine();
         }

--- a/Examples/MultipleFiltersOnDevice/MultipleFiltersOnDevice.csproj
+++ b/Examples/MultipleFiltersOnDevice/MultipleFiltersOnDevice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/MultipleFiltersOnDevice/Program.cs
+++ b/Examples/MultipleFiltersOnDevice/Program.cs
@@ -43,8 +43,8 @@ namespace MultipleFiltersOnDevice
 
             int readTimeoutMilliseconds = 1000;
 
-            var device1 = CaptureDeviceList.Instance[i];
-            var device2 = CaptureDeviceList.New()[i]; // NOTE: the call to New()
+            using var device1 = CaptureDeviceList.Instance[i];
+            using var device2 = CaptureDeviceList.New()[i]; // NOTE: the call to New()
 
             // Register our handler function to the 'packet arrival' event
             device1.OnPacketArrival +=
@@ -83,10 +83,6 @@ namespace MultipleFiltersOnDevice
             // Print out the device statistics
             Console.WriteLine("device1 {0}", device1.Statistics.ToString());
             Console.WriteLine("device2 {0}", device2.Statistics.ToString());
-
-            // Close the pcap device
-            device1.Close();
-            device2.Close();
         }
 
         /// <summary>

--- a/Examples/NpcapRemoteCapture/NpcapRemoteCapture.csproj
+++ b/Examples/NpcapRemoteCapture/NpcapRemoteCapture.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/NpcapRemoteCapture/Program.cs
+++ b/Examples/NpcapRemoteCapture/Program.cs
@@ -38,7 +38,7 @@ namespace NpcapRemoteCapture
             }
 
             // open the device for capture
-            var device = remoteDevices[0];
+            using var device = remoteDevices[0];
 
             device.OnPacketArrival += new SharpPcap.PacketArrivalEventHandler(dev_OnPacketArrival);
 
@@ -61,9 +61,6 @@ namespace NpcapRemoteCapture
 
             // Print out the device statistics
             Console.WriteLine(device.Statistics.ToString());
-
-            // Close the pcap device
-            device.Close();
         }
 
         static void dev_OnPacketArrival(object sender, SharpPcap.CaptureEventArgs e)

--- a/Examples/QueuingPacketsForBackgroundProcessing/Program.cs
+++ b/Examples/QueuingPacketsForBackgroundProcessing/Program.cs
@@ -87,7 +87,7 @@ namespace QueuingPacketsForBackgroundProcessing
             var backgroundThread = new System.Threading.Thread(BackgroundThread);
             backgroundThread.Start();
 
-            var device = CaptureDeviceList.Instance[i];
+            using var device = CaptureDeviceList.Instance[i];
 
             // Register our handler function to the 'packet arrival' event
             device.OnPacketArrival +=
@@ -120,9 +120,6 @@ namespace QueuingPacketsForBackgroundProcessing
 
             // Print out the device statistics
             Console.WriteLine(device.Statistics.ToString());
-
-            // Close the pcap device
-            device.Close();
         }
 
         /// <summary>

--- a/Examples/QueuingPacketsForBackgroundProcessing/QueuingPacketsForBackgroundProcessing.csproj
+++ b/Examples/QueuingPacketsForBackgroundProcessing/QueuingPacketsForBackgroundProcessing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/ReadingCaptureFile/ReadingCaptureFile.csproj
+++ b/Examples/ReadingCaptureFile/ReadingCaptureFile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/WakeOnLan/Program.cs
+++ b/Examples/WakeOnLan/Program.cs
@@ -62,8 +62,8 @@ namespace WakeOnLan
             Console.Write("-- Please choose a device to capture: ");
             i = int.Parse(Console.ReadLine());
 
-            var device1 = devices[i];
-            var device2 = CaptureDeviceList.New()[i];
+            using var device1 = devices[i];
+            using var device2 = CaptureDeviceList.New()[i];
 
             // register our handler function to the 'packet arrival' event
             device1.OnPacketArrival +=
@@ -86,12 +86,6 @@ namespace WakeOnLan
             // start capture packets
             device1.Capture();
             device2.Capture();
-
-            // close the pcap device
-            // note: this line will never be called since
-            //  we're capturing infinite number of packets
-            device1.Close();
-            device2.Close();
         }
 
         /// <summary>

--- a/Examples/WakeOnLan/WakeOnLan.csproj
+++ b/Examples/WakeOnLan/WakeOnLan.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SharpPcap\SharpPcap.csproj" />

--- a/Examples/WinformsExample/WinformsExample.csproj
+++ b/Examples/WinformsExample/WinformsExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <ItemGroup>

--- a/SharpPcap/ICaptureDevice.cs
+++ b/SharpPcap/ICaptureDevice.cs
@@ -24,7 +24,7 @@ namespace SharpPcap
     /// <summary>
     /// Interfaces for capture devices
     /// </summary>
-    public interface ICaptureDevice
+    public interface ICaptureDevice : IDisposable
     {
         /// <summary>
         /// Gets the name of the device

--- a/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
@@ -120,6 +120,11 @@ namespace SharpPcap.LibPcap
                 throw new NotSupportedOnCaptureFileException("Statistics not supported on a capture file");
             }
         }
+
+        public override void SendPacket(ReadOnlySpan<byte> p)
+        {
+            throw new NotSupportedOnCaptureFileException("Sending not supported on a capture file");
+        }
     }
 }
 

--- a/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
@@ -208,7 +208,7 @@ namespace SharpPcap.LibPcap
         /// <summary>
         /// Open the device
         /// </summary>
-        public void Open()
+        public override void Open(DeviceModes mode = DeviceModes.None, int read_timeout = 1000, MonitorMode monitor_mode = MonitorMode.Inactive, uint kernel_buffer_size = 0)
         {
             // Nothing to do here, device is already opened and active upon construction
             Active = true;
@@ -273,6 +273,11 @@ namespace SharpPcap.LibPcap
             var header = new PcapHeader((uint)timeval.Seconds, (uint)timeval.MicroSeconds,
                                         (uint)data.Length, (uint)data.Length);
             Write(data, header);
+        }
+
+        public override void SendPacket(ReadOnlySpan<byte> p)
+        {
+            throw new NotSupportedOnCaptureFileException("Sending not supported on a capture file");
         }
     }
 }

--- a/SharpPcap/LibPcap/LibPcapLiveDevice.cs
+++ b/SharpPcap/LibPcap/LibPcapLiveDevice.cs
@@ -112,11 +112,6 @@ namespace SharpPcap.LibPcap
                     throw new InvalidOperationException("pcap_set_buffer_size() failed - return value " + retval);
                 }
             }
-
-            get
-            {
-                throw new NotImplementedException();
-            }
         }
 
         /// <summary>

--- a/SharpPcap/LibPcap/PcapDevice.cs
+++ b/SharpPcap/LibPcap/PcapDevice.cs
@@ -218,10 +218,7 @@ namespace SharpPcap.LibPcap
         /// <param name="kernel_buffer_size">
         /// A <see cref="uint"/>
         /// </param>
-        public virtual void Open(DeviceModes mode = DeviceModes.None, int read_timeout = 1000, MonitorMode monitor_mode = MonitorMode.Inactive, uint kernel_buffer_size = 0)
-        {
-            throw new NotImplementedException();
-        }
+        public abstract void Open(DeviceModes mode = DeviceModes.None, int read_timeout = 1000, MonitorMode monitor_mode = MonitorMode.Inactive, uint kernel_buffer_size = 0);
 
         /// <summary>
         /// Closes this adapter
@@ -243,13 +240,7 @@ namespace SharpPcap.LibPcap
             PcapHandle = IntPtr.Zero;
 
             //Remove event handlers
-            if (OnPacketArrival != null)
-            {
-                foreach (PacketArrivalEventHandler pa in OnPacketArrival.GetInvocationList())
-                {
-                    OnPacketArrival -= pa;
-                }
-            }
+            OnPacketArrival = null;
         }
 
         /// <summary>
@@ -267,14 +258,7 @@ namespace SharpPcap.LibPcap
         {
             get
             {
-                ThrowIfNotOpen("device not open");
-
                 return Interface.MacAddress;
-            }
-
-            set
-            {
-                throw new NotImplementedException();
             }
         }
 
@@ -616,10 +600,7 @@ namespace SharpPcap.LibPcap
         /// </summary>
         /// <param name="p">The packet bytes to send</param>
         /// <param name="size">The number of bytes to send</param>
-        public virtual void SendPacket(ReadOnlySpan<byte> p)
-        {
-            throw new NotImplementedException();
-        }
+        public abstract void SendPacket(ReadOnlySpan<byte> p);
 
         /// <summary>
         /// Helper method for checking that the adapter is open, throws an
@@ -680,6 +661,16 @@ namespace SharpPcap.LibPcap
             {
                 dev.Close();
             }
+        }
+
+        ~PcapDevice()
+        {
+            Close();
+        }
+
+        public void Dispose()
+        {
+            Close();
         }
     }
 }

--- a/SharpPcap/LibPcap/PcapDevice.cs
+++ b/SharpPcap/LibPcap/PcapDevice.cs
@@ -225,6 +225,9 @@ namespace SharpPcap.LibPcap
         /// </summary>
         public virtual void Close()
         {
+            //Remove event handlers
+            OnPacketArrival = null;
+
             if (PcapHandle == IntPtr.Zero)
                 return;
 
@@ -238,9 +241,6 @@ namespace SharpPcap.LibPcap
             }
             LibPcapSafeNativeMethods.pcap_close(PcapHandle);
             PcapHandle = IntPtr.Zero;
-
-            //Remove event handlers
-            OnPacketArrival = null;
         }
 
         /// <summary>

--- a/SharpPcap/Npcap/NpcapDevice.cs
+++ b/SharpPcap/Npcap/NpcapDevice.cs
@@ -170,14 +170,7 @@ namespace SharpPcap.Npcap
         /// </summary>
         public override void Close()
         {
-            if (OnPcapStatistics != null)
-            {
-                foreach (StatisticsModeEventHandler pse in OnPcapStatistics.GetInvocationList())
-                {
-                    OnPcapStatistics -= pse;
-                }
-            }
-
+            OnPcapStatistics = null;
             // call the base method
             base.Close();
         }
@@ -217,11 +210,6 @@ namespace SharpPcap.Npcap
                 {
                     throw new InvalidOperationException("pcap_setbuff() failed");
                 }
-            }
-
-            get
-            {
-                throw new NotImplementedException();
             }
         }
 

--- a/SharpPcap/WinDivert/WinDivertDevice.cs
+++ b/SharpPcap/WinDivert/WinDivertDevice.cs
@@ -338,5 +338,15 @@ namespace SharpPcap.WinDivert
             var err = Marshal.GetLastWin32Error();
             ThrowWin32Error(message, err);
         }
+
+        ~WinDivertDevice()
+        {
+            Close();
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
     }
 }

--- a/Test/CaptureFileReaderTest.cs
+++ b/Test/CaptureFileReaderTest.cs
@@ -36,15 +36,13 @@ namespace Test
         [Test]
         public void CaptureFinite()
         {
-            var device = new CaptureFileReaderDevice(TestHelper.GetFile("ipv6_http.pcap"));
+            using var device = new CaptureFileReaderDevice(TestHelper.GetFile("ipv6_http.pcap"));
             device.OnPacketArrival += HandleDeviceOnPacketArrival;
             device.Open();
 
             var expectedPackets = 3;
             capturedPackets = 0;
             device.Capture(expectedPackets);
-
-            device.Close();
 
             Assert.AreEqual(expectedPackets, capturedPackets);
         }
@@ -82,7 +80,7 @@ namespace Test
         [Test]
         public void SetFilter()
         {
-            var device = new CaptureFileReaderDevice(TestHelper.GetFile("test_stream.pcap"));
+            using var device = new CaptureFileReaderDevice(TestHelper.GetFile("test_stream.pcap"));
 
             device.Open();
             device.Filter = "port 53";
@@ -104,8 +102,6 @@ namespace Test
             } while (rawPacket != null);
 
             Assert.AreEqual(1, count);
-
-            device.Close(); // close the device
         }
     }
 }

--- a/Test/CaptureFileWriterTest.cs
+++ b/Test/CaptureFileWriterTest.cs
@@ -17,9 +17,10 @@ namespace Test
         [Test]
         public void TestFileCreationAndDeletion()
         {
-            var wd = new CaptureFileWriterDevice(@"abc.pcap");
-            wd.Write(new byte[] { 1, 2, 3, 4 });
-            wd.Close();
+            using (var wd = new CaptureFileWriterDevice(@"abc.pcap"))
+            {
+                wd.Write(new byte[] { 1, 2, 3, 4 });
+            }
             System.IO.File.Delete(@"abc.pcap");
         }
     }

--- a/Test/LivePcapDeviceSetFilterTest.cs
+++ b/Test/LivePcapDeviceSetFilterTest.cs
@@ -21,15 +21,13 @@ namespace Test
                 LinkLayers.Raw,
                 LinkLayers.Null
             };
-            var device = fixture.GetDevice();
+            using var device = fixture.GetDevice();
             device.Open();
             if (!supportedLinks.Contains(device.LinkType))
             {
-                device.Close();
                 Assert.Inconclusive("NFLOG link-layer not supported");
             }
             device.Filter = "tcp port 80";
-            device.Close(); // close the device
         }
 
         /// <summary>

--- a/Test/Npcap/NpcapDeviceTest.cs
+++ b/Test/Npcap/NpcapDeviceTest.cs
@@ -41,24 +41,11 @@ namespace Test.Npcap
                                                            " on windows?");
             }
 
-            devices[0].Open();
-            devices[0].OnPcapStatistics += (sender, args) => { };
+            using var device = devices[0];
+            device.Open();
+            device.OnPcapStatistics += (sender, args) => { };
 
-            bool caughtException = false;
-
-            try
-            {
-                // start background capture
-                devices[0].StartCapture();
-            }
-            catch (DeviceNotReadyException)
-            {
-                caughtException = true;
-            }
-
-            Assert.IsFalse(caughtException);
-
-            devices[0].Close();
+            Assert.DoesNotThrow(() => device.StartCapture());
         }
 
         /// <summary>
@@ -76,23 +63,10 @@ namespace Test.Npcap
                                                            " on windows?");
             }
 
-            devices[0].Open();
+            using var device = devices[0];
+            device.Open();
 
-            bool caughtExpectedException = false;
-
-            try
-            {
-                // start background capture
-                devices[0].StartCapture();
-            }
-            catch (DeviceNotReadyException)
-            {
-                caughtExpectedException = true;
-            }
-
-            Assert.IsTrue(caughtExpectedException);
-
-            devices[0].Close();
+            Assert.Throws<DeviceNotReadyException>(() => device.StartCapture());
         }
     }
 }

--- a/Test/Performance/PacketParsing.cs
+++ b/Test/Performance/PacketParsing.cs
@@ -2,6 +2,7 @@ using System;
 using SharpPcap;
 using PacketDotNet;
 using NUnit.Framework;
+using SharpPcap.LibPcap;
 
 namespace Test.Performance
 {
@@ -18,7 +19,7 @@ namespace Test.Performance
             var startTime = DateTime.Now;
             while (packetsRead < packetsToRead)
             {
-                var captureDevice = new SharpPcap.LibPcap.CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
+                using var captureDevice = new CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
                 captureDevice.Open();
 
                 RawCapture rawCapture = null;
@@ -34,7 +35,6 @@ namespace Test.Performance
                 }
                 while (rawCapture != null);
 
-                captureDevice.Close();
             }
 
             var endTime = DateTime.Now;
@@ -55,7 +55,7 @@ namespace Test.Performance
             var startTime = DateTime.Now;
             while (packetsRead < packetsToRead)
             {
-                ICaptureDevice captureDevice = new SharpPcap.LibPcap.CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
+                using var captureDevice = new CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
                 captureDevice.Open();
 
                 RawCapture rawCapture = null;
@@ -71,7 +71,6 @@ namespace Test.Performance
                 }
                 while (rawCapture != null);
 
-                captureDevice.Close();
             }
 
             var endTime = DateTime.Now;
@@ -92,7 +91,7 @@ namespace Test.Performance
             var startTime = DateTime.Now;
             while (packetsRead < packetsToRead)
             {
-                ICaptureDevice captureDevice = new SharpPcap.LibPcap.CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
+                using var captureDevice = new CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
                 captureDevice.Open();
 
                 RawCapture rawCapture = null;
@@ -108,7 +107,6 @@ namespace Test.Performance
                 }
                 while (rawCapture != null);
 
-                captureDevice.Close();
             }
 
             var endTime = DateTime.Now;

--- a/Test/Performance/PacketReading.cs
+++ b/Test/Performance/PacketReading.cs
@@ -1,6 +1,7 @@
 using System;
 using SharpPcap;
 using NUnit.Framework;
+using SharpPcap.LibPcap;
 
 namespace Test.Performance
 {
@@ -17,7 +18,7 @@ namespace Test.Performance
             var startTime = DateTime.Now;
             while (packetsRead < packetsToRead)
             {
-                var captureDevice = new SharpPcap.LibPcap.CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
+                using var captureDevice = new CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
                 captureDevice.Open();
 
                 RawCapture rawCapture = null;
@@ -28,7 +29,6 @@ namespace Test.Performance
                 }
                 while (rawCapture != null);
 
-                captureDevice.Close();
             }
 
             var endTime = DateTime.Now;
@@ -46,7 +46,7 @@ namespace Test.Performance
             var startTime = DateTime.Now;
             while (packetsRead < packetsToRead)
             {
-                ICaptureDevice captureDevice = new SharpPcap.LibPcap.CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
+                using var captureDevice = new CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
                 captureDevice.Open();
 
                 RawCapture rawCapture = null;
@@ -56,8 +56,6 @@ namespace Test.Performance
                     packetsRead++;
                 }
                 while (rawCapture != null);
-
-                captureDevice.Close();
             }
 
             var endTime = DateTime.Now;
@@ -75,7 +73,7 @@ namespace Test.Performance
             var startTime = DateTime.Now;
             while (packetsRead < packetsToRead)
             {
-                ICaptureDevice captureDevice = new SharpPcap.LibPcap.CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
+                using var captureDevice = new CaptureFileReaderDevice(TestHelper.GetFile("10k_packets.pcap"));
                 captureDevice.Open();
 
                 RawCapture rawCapture = null;
@@ -85,8 +83,6 @@ namespace Test.Performance
                     packetsRead++;
                 }
                 while (rawCapture != null);
-
-                captureDevice.Close();
             }
 
             var endTime = DateTime.Now;

--- a/Test/SendQueueTest.cs
+++ b/Test/SendQueueTest.cs
@@ -29,7 +29,8 @@ namespace Test
                     GetSendQueue().NativeTransmit(device, SendQueueTransmitModes.Normal);
                 });
                 AssertGoodTransmitNormal(received);
-            } else
+            }
+            else
             {
                 Assert.Ignore("Skipping test as no hardware acceleration is present");
             }
@@ -45,7 +46,8 @@ namespace Test
                     GetSendQueue().NativeTransmit(device, SendQueueTransmitModes.Synchronized);
                 });
                 AssertGoodTransmitSync(received);
-            } else
+            }
+            else
             {
                 Assert.Ignore("Skipping test as no hardware acceleration is present");
             }
@@ -88,20 +90,14 @@ namespace Test
         {
             if (SendQueue.IsHardwareAccelerated)
             {
-                var device = GetPcapDevice();
+                using var device = GetPcapDevice();
                 device.Open();
-                try
-                {
-                    var queue = GetSendQueue();
-                    var managed = queue.ManagedTransmit(device, SendQueueTransmitModes.Normal);
-                    var native = queue.NativeTransmit(device, SendQueueTransmitModes.Normal);
-                    Assert.AreEqual(managed, native);
-                }
-                finally
-                {
-                    device.Close();
-                }
-            } else
+                var queue = GetSendQueue();
+                var managed = queue.ManagedTransmit(device, SendQueueTransmitModes.Normal);
+                var native = queue.NativeTransmit(device, SendQueueTransmitModes.Normal);
+                Assert.AreEqual(managed, native);
+            }
+            else
             {
                 Assert.Ignore("Skipping test as no hardware acceleration is present");
             }

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net48</TargetFrameworks>
     <CoverletOutputFormat>opencover</CoverletOutputFormat>
   </PropertyGroup>
   <ItemGroup>

--- a/Test/TestHelper.cs
+++ b/Test/TestHelper.cs
@@ -76,7 +76,7 @@ namespace Test
         /// <returns></returns>
         internal static List<RawCapture> RunCapture(string filter, Action<PcapDevice> routine)
         {
-            var device = GetPcapDevice();
+            using var device = GetPcapDevice();
             Console.WriteLine($"Using device {device}");
             var received = new List<RawCapture>();
             var mode = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
@@ -94,7 +94,7 @@ namespace Test
                 sender = new LibPcapLiveDevice(device.Interface);
                 sender.Open(mode, 1);
             }
-            try
+            using(sender)
             {
                 routine(sender);
                 // waiting for any queued packets to be sent
@@ -120,11 +120,6 @@ namespace Test
                     }
 
                 }
-            }
-            finally
-            {
-                sender.Close();
-                device.Close();
             }
             return received;
         }

--- a/Test/WinDivert/WinDivertDeviceTest.cs
+++ b/Test/WinDivert/WinDivertDeviceTest.cs
@@ -61,20 +61,19 @@ namespace Test.WinDivert
         [Test]
         public void TestGetNextPacket()
         {
-            var device = new WinDivertDevice
+            using var device = new WinDivertDevice
             {
                 Filter = "!loopback and tcp"
             };
             device.Open();
             var capture = device.GetNextPacket();
-            device.Close();
             AssertTcp(capture);
         }
 
         [Test]
         public void TestCapture()
         {
-            var device = new WinDivertDevice
+            using var device = new WinDivertDevice
             {
                 Filter = "!loopback and tcp"
             };
@@ -87,7 +86,6 @@ namespace Test.WinDivert
             device.StartCapture();
             Thread.Sleep(10000);
             device.StopCapture();
-            device.Close();
             Assert.That(received, Has.Count.AtLeast(2));
             foreach (var capture in received)
             {
@@ -116,24 +114,17 @@ namespace Test.WinDivert
             var ifIndex = nic.GetIPProperties().GetIPv4Properties().Index;
             Console.WriteLine($"Using NIC {nic.Name} [{ifIndex}]");
             Console.WriteLine($"Sending from {src} to {dst}");
-            var device = new WinDivertDevice();
+            using var device = new WinDivertDevice();
             device.Open();
-            try
-            {
-                var udp = new UdpPacket(5000, 5000);
-                udp.PayloadData = new byte[100];
-                var ip = IPv4Packet.RandomPacket();
-                ip.PayloadPacket = udp;
+            var udp = new UdpPacket(5000, 5000);
+            udp.PayloadData = new byte[100];
+            var ip = IPv4Packet.RandomPacket();
+            ip.PayloadPacket = udp;
 
-                ip.SourceAddress = src;
-                ip.DestinationAddress = dst;
+            ip.SourceAddress = src;
+            ip.DestinationAddress = dst;
 
-                device.SendPacket(ip);
-            }
-            finally
-            {
-                device.Close();
-            }
+            device.SendPacket(ip);
         }
 
     }


### PR DESCRIPTION
Uses `IDisposable` to make tracking non-closed devices easier, in Code Analysis Tools
PR split into 3 commits for easier review.