### PR TITLE
Add support for more configuration options. Allow detecting partially failed configuration.

### DIFF
--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Unix.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Unix.cs
@@ -73,6 +73,9 @@ namespace SharpPcap.LibPcap
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_set_buffer_size(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes);
 
+        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_set_immediate_mode(IntPtr /* pcap_t */ adapter, int immediate_mode);
+
         /// <summary>Open a file to write packets. </summary>
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static IntPtr /*pcap_dumper_t * */ pcap_dump_open(IntPtr /*pcap_t * */adaptHandle, string /*const char * */fname);

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Windows.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Windows.cs
@@ -88,6 +88,9 @@ namespace SharpPcap.LibPcap
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_set_buffer_size(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes);
 
+        [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static int pcap_set_immediate_mode(IntPtr /* pcap_t */ adapter, int immediate_mode);
+
         /// <summary>Open a file to write packets. </summary>
         [DllImport(PCAP_DLL, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal extern static IntPtr /*pcap_dumper_t * */ pcap_dump_open(IntPtr /*pcap_t * */adaptHandle, string /*const char * */fname);

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -127,6 +127,11 @@ namespace SharpPcap.LibPcap
             return UseWindows ? Windows.pcap_set_buffer_size(adapter, bufferSizeInBytes) : Unix.pcap_set_buffer_size(adapter, bufferSizeInBytes);
         }
 
+        internal static int pcap_set_immediate_mode(IntPtr /* pcap_t */ adapter, int immediate_mode)
+        {
+            return UseWindows ? Windows.pcap_set_immediate_mode(adapter, immediate_mode) : Unix.pcap_set_immediate_mode(adapter, immediate_mode);
+        }
+
         internal static int pcap_setbuff(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes)
         {
             return UseWindows ? Windows.pcap_setbuff(adapter, bufferSizeInBytes) : 0;
@@ -359,7 +364,14 @@ namespace SharpPcap.LibPcap
         /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
         internal static int pcap_set_rfmon(IntPtr /* pcap_t* */ p, int rfmon)
         {
-            return UseWindows ? Windows.pcap_set_rfmon(p, rfmon) : Unix.pcap_set_rfmon(p, rfmon);
+            try
+            {
+                return UseWindows ? Windows.pcap_set_rfmon(p, rfmon) : Unix.pcap_set_rfmon(p, rfmon);
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return (int)PcapError.RfmonNotSupported;
+            }
         }
 
         /// <summary>

--- a/SharpPcap/PcapError.cs
+++ b/SharpPcap/PcapError.cs
@@ -1,0 +1,78 @@
+﻿/*
+This file is part of SharpPcap.
+
+SharpPcap is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SharpPcap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ */
+
+namespace SharpPcap
+{
+    /// <summary>
+    /// Error codes for the pcap API.
+    /// See <code>#define PCAP_ERROR*</code> in https://github.com/the-tcpdump-group/libpcap/blob/master/pcap/pcap.h
+    /// </summary>
+    public enum PcapError
+    {
+        /// <summary>
+        /// generic error code
+        /// </summary>
+        Generic = -1,
+        /// <summary>
+        /// loop terminated by pcap_breakloop
+        /// </summary>
+        Break = -2,
+        /// <summary>
+        /// the capture needs to be activated
+        /// </summary>
+        NotActivated = -3,
+        /// <summary>
+        /// the operation can't be performed on already activated captures
+        /// </summary>
+        Activated = -4,
+        /// <summary>
+        ///  no such device exists
+        /// </summary>
+        NoSuchDevice = -5,
+        /// <summary>
+        /// this device doesn't support rfmon (monitor) mode
+        /// </summary>
+        RfmonNotSupported = -6,
+        /// <summary>
+        /// operation supported only in monitor mode
+        /// </summary>
+        NotRfmon = -7,
+        /// <summary>
+        /// no permission to open the device
+        /// </summary>
+        PermissionDenied = -8,
+        /// <summary>
+        /// interface isn't up
+        /// </summary>
+        InterfaceNotUp = -9,
+        /// <summary>
+        /// this device doesn't support setting the time stamp type
+        /// </summary>
+        TimestampTypeNotSupported = -10,
+        /// <summary>
+        /// you don't have permission to capture in promiscuous mode
+        /// </summary>
+        PromiscuousPermissionDenied = -11,
+        /// <summary>
+        /// the requested time stamp precision is not supported
+        /// </summary>
+        TimestampPrecisionNotSupported = -12,
+    }
+}

--- a/Test/RemotePcapTests.cs
+++ b/Test/RemotePcapTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Net;
 using SharpPcap.LibPcap;
 using SharpPcap;
+using static Test.TestHelper;
 
 namespace Test
 {
@@ -89,12 +90,12 @@ namespace Test
                     }
 
                     Assert.Throws<PcapException>(
-                        () => npcapDevices[0].Open(new DeviceConfiguration
+                        () => npcapDevices[0].Open(StrictConfig(new DeviceConfiguration
                         {
                             Mode = DeviceModes.NoCaptureRemote,
                             ReadTimeout = 1,
                             Credentials = badCred
-                        }),
+                        })),
                         "Credentials provided to Open() method takes precedence"
                     );
 

--- a/Test/TestHelper.cs
+++ b/Test/TestHelper.cs
@@ -142,5 +142,16 @@ namespace Test
                 }
             }
         }
+
+        public static DeviceConfiguration StrictConfig(DeviceConfiguration configuration)
+        {
+            configuration.ConfigurationFailed += Configuration_ConfigurationFailed;
+            return configuration;
+        }
+
+        private static void Configuration_ConfigurationFailed(object sender, ConfigurationFailedEventArgs e)
+        {
+            Assert.Fail(e.Message);
+        }
     }
 }


### PR DESCRIPTION
@chmorgan I expect some tests to fail on the first run due to platform support (I need them to fail on purpose to see what platform can do what).
regardless a review of the idea/concept would be appreciated.