### PR TITLE
Move MinToCopy to DeviceConfiguration

### DIFF
--- a/SharpPcap/DeviceConfiguration.cs
+++ b/SharpPcap/DeviceConfiguration.cs
@@ -44,6 +44,8 @@ namespace SharpPcap
 
         public bool? Immediate { get; set; }
 
+        public int? MinToCopy { get; set; }
+
         public event EventHandler<ConfigurationFailedEventArgs> ConfigurationFailed;
 
         internal void RaiseConfigurationFailed(string property, int retval)

--- a/SharpPcap/LibPcap/LibPcapLiveDevice.cs
+++ b/SharpPcap/LibPcap/LibPcapLiveDevice.cs
@@ -239,6 +239,23 @@ namespace SharpPcap.LibPcap
                         Windows.pcap_setmintocopy, 0
                     );
                 }
+                if (configuration.MinToCopy.HasValue)
+                {
+                    if (mintocopy_supported)
+                    {
+                        Configure(
+                            configuration, nameof(configuration.MinToCopy),
+                            Windows.pcap_setmintocopy, configuration.MinToCopy.Value
+                        );
+                    }
+                    else
+                    {
+                        configuration.RaiseConfigurationFailed(
+                            nameof(configuration.MinToCopy),
+                            new PlatformNotSupportedException()
+                        );
+                    }
+                }
             }
         }
 

--- a/SharpPcap/Npcap/NpcapDevice.cs
+++ b/SharpPcap/Npcap/NpcapDevice.cs
@@ -119,26 +119,6 @@ namespace SharpPcap.Npcap
             }
         }
 
-        /// <value>
-        /// Set the minumum amount of data (in bytes) received by the kernel in a single call. 
-        /// Npcap extension
-        /// </value>
-        public int MinToCopy
-        {
-            set
-            {
-                ThrowIfNotNpcap();
-                ThrowIfNotOpen("Can't set MinToCopy size, the device is not opened");
-
-                int retval = Windows.pcap_setmintocopy(this.m_pcapAdapterHandle,
-                                                                 value);
-                if (retval != 0)
-                {
-                    throw new InvalidOperationException("pcap_setmintocopy() failed");
-                }
-            }
-        }
-
         /// <summary>
         /// Helper method for ensuring we are running in npcap. Throws
         /// a NpcapRequiredException() if not on a windows platform

--- a/Test/PcapDeviceTest.cs
+++ b/Test/PcapDeviceTest.cs
@@ -72,27 +72,27 @@ namespace Test
 
         [Test]
         [Platform("Win")]
-        public void KernelBufferSize_Windows()
+        [TestCase("KernelBufferSize", 64 * 1000 * 1000)]
+        [TestCase("MinToCopy", 10000)]
+        public void Configuration_Windows(string property, int value)
         {
             using var device = GetPcapDevice();
-            var size_64mb = 64 * 1024 * 1024;
 
-            device.Open(StrictConfig(new DeviceConfiguration
-            {
-                KernelBufferSize = size_64mb,
-            }));
+            var config = new DeviceConfiguration();
+            config.GetType().GetProperty(property).SetValue(config, value);
+
+            device.Open(StrictConfig(config));
         }
 
         [Test]
         [Platform(Exclude = "Win")]
-        public void KernelBufferSize_Unix()
+        [TestCase("KernelBufferSize", 64 * 1000 * 1000)]
+        [TestCase("MinToCopy", 10000)]
+        public void Configuration_NotWindows(string property, int value)
         {
             using var device = GetPcapDevice();
-            var size_64mb = 64 * 1024 * 1024;
-            var config = new DeviceConfiguration
-            {
-                KernelBufferSize = size_64mb
-            };
+            var config = new DeviceConfiguration();
+            config.GetType().GetProperty(property).SetValue(config, value);
             var failures = new List<ConfigurationFailedEventArgs>();
             config.ConfigurationFailed += (s, e) =>
             {
@@ -101,7 +101,7 @@ namespace Test
             device.Open(config);
             Assert.That(failures, Has.Count.EqualTo(1));
             var fail = failures[0];
-            Assert.AreEqual("KernelBufferSize", fail.Property);
+            Assert.AreEqual(property, fail.Property);
             Assert.AreEqual(PcapError.Generic, fail.Error);
             StringAssert.Contains(new PlatformNotSupportedException().Message, fail.Message);
         }


### PR DESCRIPTION
With this PR, the only thing left that is NpcapDevice specific is Statistics Mode