### PR TITLE
DeviceConfiguration - Throw if no ConfigurationFailed event handlers …

### DIFF
--- a/SharpPcap/DeviceConfiguration.cs
+++ b/SharpPcap/DeviceConfiguration.cs
@@ -64,8 +64,10 @@ namespace SharpPcap
                 Property = property,
                 Error = error,
                 Message = message,
+                Exception = new PcapException(message),
             };
-            ConfigurationFailed?.Invoke(this, args);
+
+            RaiseFailedEvent(args);
         }
 
         internal void RaiseConfigurationFailed(string property, Exception exception)
@@ -76,10 +78,23 @@ namespace SharpPcap
                 Property = property,
                 Error = PcapError.Generic,
                 Message = message,
+                Exception = exception,
             };
-            ConfigurationFailed?.Invoke(this, args);
+
+            RaiseFailedEvent(args);
         }
 
+        private void RaiseFailedEvent(ConfigurationFailedEventArgs args)
+        {
+            if (ConfigurationFailed is null)
+            {
+                throw args.Exception;
+            }
+            else
+            {
+                ConfigurationFailed.Invoke(this, args);
+            }
+        }
     }
 
     public class ConfigurationFailedEventArgs : EventArgs
@@ -87,5 +102,6 @@ namespace SharpPcap
         public PcapError Error { get; internal set; }
         public string Property { get; internal set; }
         public string Message { get; internal set; }
+        public Exception Exception { get; internal set; }
     }
 }

--- a/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
@@ -113,10 +113,7 @@ namespace SharpPcap.LibPcap
         {
             if (configuration.Snaplen > Pcap.MAX_PACKET_SIZE)
             {
-                var ex = new InvalidOperationException("Snaplen > Pcap.MAX_PACKET_SIZE");
-                configuration.RaiseConfigurationFailed("snaplen", ex);
-
-                throw ex;
+                configuration.RaiseConfigurationFailed("snaplen", new InvalidOperationException("Snaplen > Pcap.MAX_PACKET_SIZE"));
             }
 
             // set the device handle


### PR DESCRIPTION
…have been defined. When an exception is available preserve it so we retain its type.


How does this look for restoring exceptions when the user isn't desiring to receive them as configuration errors?