### PR TITLE
Add LibpcapVersionAttribute

### DIFF
--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -485,6 +485,7 @@ namespace SharpPcap.LibPcap
 
         #region Timestamp related functions
 
+        private static readonly Version Libpcap_1_5 = new Version(1, 5, 0);
         /// <summary>
         /// Available since libpcap 1.5
         /// </summary>
@@ -493,6 +494,10 @@ namespace SharpPcap.LibPcap
         /// <returns></returns>
         internal static int pcap_set_tstamp_precision(IntPtr /* pcap_t* p */ adapter, int precision)
         {
+            if (Pcap.LibpcapVersion < Libpcap_1_5)
+            {
+                return (int)PcapError.TimestampPrecisionNotSupported;
+            }
             return UseWindows ?
                 Windows.pcap_set_tstamp_precision(adapter, precision) :
                 Unix.pcap_set_tstamp_precision(adapter, precision);
@@ -504,15 +509,13 @@ namespace SharpPcap.LibPcap
         /// <param name="adapter"></param>
         internal static int pcap_get_tstamp_precision(IntPtr /* pcap_t* p */ adapter)
         {
-            try
+            if (Pcap.LibpcapVersion < Libpcap_1_5)
             {
-                return UseWindows ?
-                    Windows.pcap_get_tstamp_precision(adapter) :
-                    Unix.pcap_get_tstamp_precision(adapter);
-            } catch(EntryPointNotFoundException)
-            {
-                throw new NotSupportedException("pcap_get_tstamp_precision()");
+                return (int)TimestampResolution.Microsecond;
             }
+            return UseWindows ?
+                Windows.pcap_get_tstamp_precision(adapter) :
+                Unix.pcap_get_tstamp_precision(adapter);
         }
 
         /// <summary>
@@ -547,10 +550,11 @@ namespace SharpPcap.LibPcap
         /// <param name="types_pointer"></param>
         internal static void pcap_free_tstamp_types(IntPtr types_pointer)
         {
-            if(UseWindows)
+            if (UseWindows)
             {
                 Windows.pcap_free_tstamp_types(types_pointer);
-            } else
+            }
+            else
             {
                 Unix.pcap_free_tstamp_types(types_pointer);
             }

--- a/Test/LibpcapVersionAttribute.cs
+++ b/Test/LibpcapVersionAttribute.cs
@@ -1,0 +1,59 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using System;
+using SemVersion.Parser;
+using SemVersion;
+using SharpPcap;
+
+namespace Test
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+    public class LibpcapVersionAttribute : IncludeExcludeAttribute, IApplyToTest
+    {
+
+        /// <summary>
+        /// Constructor taking one or more platforms
+        /// </summary>
+        /// <param name="platforms">Comma-delimited list of platforms</param>
+        public LibpcapVersionAttribute(string include) : base(include) { }
+
+        /// <summary>
+        /// Causes a test to be skipped if this LibpcapVersion is not satisfied.
+        /// </summary>
+        /// <param name="test">The test to modify</param>
+        public void ApplyToTest(NUnit.Framework.Internal.Test test)
+        {
+            if (test.RunState != RunState.NotRunnable &&
+                test.RunState != RunState.Ignored)
+            {
+                try
+                {
+                    if (
+                        (Include != null && !IsVersionSupported(Include)) ||
+                        (Exclude != null && IsVersionSupported(Exclude))
+                        )
+                    {
+                        var reason = string.Format("Not supported on Libpcap v{0}", Pcap.LibpcapVersion);
+                        test.RunState = RunState.Skipped;
+                        test.Properties.Add(PropertyNames.SkipReason, reason);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    test.RunState = RunState.NotRunnable;
+                    test.Properties.Add(PropertyNames.SkipReason, ex.Message);
+                }
+            }
+        }
+
+        private static bool IsVersionSupported(string range)
+        {
+            var parser = new RangeParser();
+            var predicate = parser.Evaluate(range);
+            var v = Pcap.LibpcapVersion;
+            var version = new SemanticVersion(v.Major, v.Minor, Math.Max(v.Build, 0));
+            return predicate(version);
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
+    <PackageReference Include="SemanticVersion" Version="2.1.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Usage
```cs
        [Test]
        [LibpcapVersion(">2.0.0")]
        public void LibpcapVersionAttributeTest()
        {
            // Test will only run if libpcap version > 2.0.0
            Assert.Fail("Libpcap coming from the future");
        }
```
See https://docs.npmjs.com/cli/v6/using-npm/semver for examples on ranges