### PR TITLE
Fix parse of pcap_list_tstamp_types

### DIFF
--- a/SharpPcap/LibPcap/PcapInterface.cs
+++ b/SharpPcap/LibPcap/PcapInterface.cs
@@ -284,7 +284,7 @@ namespace SharpPcap.LibPcap
 
                 for (var i = 0; i < typeCount; i++)
                 {
-                    var value = Marshal.ReadInt32(typePtr);
+                    var value = Marshal.ReadInt32(typePtr, i * 4);
                     var tsValue = (TimestampType)value;
                     timestampTypes.Add(new PcapClock(tsValue));
                 }

--- a/SharpPcap/LibPcap/PcapInterface.cs
+++ b/SharpPcap/LibPcap/PcapInterface.cs
@@ -284,7 +284,7 @@ namespace SharpPcap.LibPcap
 
                 for (var i = 0; i < typeCount; i++)
                 {
-                    var value = Marshal.ReadInt32(typePtr, i * 4);
+                    var value = Marshal.ReadInt32(typePtr, i * sizeof(int));
                     var tsValue = (TimestampType)value;
                     timestampTypes.Add(new PcapClock(tsValue));
                 }

--- a/scripts/InstallNpcap.ps1
+++ b/scripts/InstallNpcap.ps1
@@ -11,13 +11,12 @@ $npcap_oem_file = "npcap-1.20-oem.exe"
 #    provide support for the /S option
 
 if (Test-Path Env:npcap_oem_key){  # Key is here: on master
-    echo "Using Npcap OEM version"
     # Unpack the key
     # The format of the environment variable should be 'username,password'
     $user, $pass = (Get-ChildItem Env:npcap_oem_key).Value.replace("`"", "").split(",")
-    if(!$user -Or !$pass){
-        Throw (New-Object System.Exception)
-    }
+}
+if($user -And $pass){
+    echo "Using Npcap OEM version"
     $file = $PSScriptRoot+"\"+$npcap_oem_file
     # Download oem file using (super) secret credentials
     $pair = "${user}:${pass}"


### PR DESCRIPTION
Add missing offset parameter. Only the first value was read from the list.