### PR TITLE
Memory Safety Checks

### DIFF
--- a/Test/MemorySafetryTests.cs
+++ b/Test/MemorySafetryTests.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using PacketDotNet;
+using SharpPcap;
+using SharpPcap.LibPcap;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using static Test.TestHelper;
+
+namespace Test
+{
+    /// <summary>
+    /// Due to race conditions, it could happen that a device handle gets closed while being used by another thread
+    /// We need to be able to at least prevent memory corruption
+    /// If this test did what it should, you will see in the logs:
+    ///     "The active test run was aborted. Reason: Test host process crashed" 
+    /// We run each test 10 times in parallel, to make libpcap reuse freed memory and crash
+    /// </summary>
+    [TestFixture]
+    [Category("MemorySafetry")]
+    public class MemorySafetryTests
+    {
+
+        private readonly PcapInterface TestInterface = GetPcapDevice().Interface;
+
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void DisposeDuringCapture([Range(1, 10)] int _)
+        {
+            using var waitHandle = new AutoResetEvent(false);
+
+            // We can't use the same device for async capturing and sending
+
+            using var receiver = new LibPcapLiveDevice(TestInterface);
+            using var sender = new LibPcapLiveDevice(TestInterface);
+
+            // Configure sender
+            sender.Open();
+
+            // Configure receiver
+            receiver.Open(DeviceModes.Promiscuous);
+            receiver.Filter = "ether proto 0xDEAD";
+            receiver.OnPacketArrival += (d, e) =>
+            {
+                try
+                {
+                    // Most simple form, dipose device while capture is running
+                    Task.Run(receiver.Dispose).Wait();
+                    // Now try to access the memory of the packet
+                    Packet.ParsePacket(LinkLayers.Ethernet, e.Data.ToArray());
+                }
+                finally
+                {
+                    // Let test close
+                    waitHandle.Set();
+                }
+            };
+            receiver.StartCapture();
+
+            // Send the packets
+            var packet = EthernetPacket.RandomPacket();
+            packet.Type = (EthernetType)0xDEAD;
+            sender.SendPacket(packet);
+
+            // Wait for packets to arrive
+            Assert.IsTrue(waitHandle.WaitOne(5000));
+        }
+
+
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void DisposeDuringTransmit([Range(1, 10)] int _)
+        {
+            using var device = new LibPcapLiveDevice(TestInterface);
+            device.Open();
+            var queue = SendQueueTest.GetSendQueue(0xDEAD);
+            Task.Run(() =>
+            {
+                Thread.Sleep(SendQueueTest.DeltaMs);
+                device.Dispose();
+            });
+            try
+            {
+                queue.Transmit(device, SendQueueTransmitModes.Synchronized);
+            }
+            catch (ObjectDisposedException)
+            {
+                // We are good, we disposed mid sending and we deserve the exception
+            }
+        }
+    }
+}

--- a/Test/SendQueueTest.cs
+++ b/Test/SendQueueTest.cs
@@ -17,7 +17,7 @@ namespace Test
     {
         private const string Filter = "ether proto 0x1234";
         private const int PacketCount = 8;
-        private static readonly int DeltaMs = 10;
+        internal static readonly int DeltaMs = 10;
 
         /// <summary>
         /// Transmit with normal works correctly
@@ -196,11 +196,11 @@ namespace Test
         /// Helper method
         /// </summary>
         /// <returns></returns>
-        private static SendQueueWrapper GetSendQueue()
+        internal static SendQueueWrapper GetSendQueue(ushort ethertype = 0x1234)
         {
             var queue = new SendQueueWrapper(1024);
             var packet = EthernetPacket.RandomPacket();
-            packet.Type = (EthernetType)0x1234;
+            packet.Type = (EthernetType)ethertype;
             for (var i = 0; i < PacketCount; i++)
             {
                 Assert.IsTrue(queue.Add(packet.Bytes, 123456, i * DeltaMs * 1000));
@@ -208,7 +208,7 @@ namespace Test
             return queue;
         }
 
-        class SendQueueWrapper : SendQueue
+        internal class SendQueueWrapper : SendQueue
         {
             public SendQueueWrapper(int memSize) : base(memSize)
             {


### PR DESCRIPTION
Tests that reproduce the scenario reported in #295

CC @KoenPlasmansLS

@chmorgan two simple tests managed to crash the test runner in every single platform ☠️ 

Obviously this PR should not be merged, and #306 that includes both the tests and the fix should b merged instead.