### PR TITLE
Use SafeHandle

### DIFF
--- a/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
@@ -91,7 +91,7 @@ namespace SharpPcap.LibPcap
             // holds errors
             StringBuilder errbuf = new StringBuilder(Pcap.PCAP_ERRBUF_SIZE); //will hold errors
 
-            IntPtr adapterHandle;
+            PcapHandle adapterHandle;
 
             // Check if we need to open with a defined precision
             var has_offline_with_tstamp_precision_support = Pcap.LibpcapVersion >= new Version(1, 5, 1);
@@ -117,16 +117,16 @@ namespace SharpPcap.LibPcap
             }
 
             // handle error
-            if (adapterHandle == IntPtr.Zero)
+            if (adapterHandle.IsInvalid)
             {
                 string err = "Unable to open offline adapter: " + errbuf.ToString();
                 throw new PcapException(err);
             }
 
             // set the device handle
-            PcapHandle = adapterHandle;
+            Handle = adapterHandle;
 
-            Active = true;
+            base.Open(configuration);
         }
 
         /// <summary>

--- a/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileWriterDevice.cs
@@ -116,7 +116,7 @@ namespace SharpPcap.LibPcap
             var resolution = configuration.TimestampResolution ?? TimestampResolution.Microsecond;
             if (has_open_dead_with_tstamp_precision_support)
             {
-                PcapHandle = LibPcapSafeNativeMethods.pcap_open_dead_with_tstamp_precision((int)configuration.LinkLayerType,
+                Handle = LibPcapSafeNativeMethods.pcap_open_dead_with_tstamp_precision((int)configuration.LinkLayerType,
                     configuration.Snaplen,
                     (uint)resolution);
             }
@@ -131,14 +131,14 @@ namespace SharpPcap.LibPcap
                     );
                 }
 
-                PcapHandle = LibPcapSafeNativeMethods.pcap_open_dead((int)configuration.LinkLayerType, configuration.Snaplen);
+                Handle = LibPcapSafeNativeMethods.pcap_open_dead((int)configuration.LinkLayerType, configuration.Snaplen);
             }
 
-            m_pcapDumpHandle = LibPcapSafeNativeMethods.pcap_dump_open(PcapHandle, m_pcapFile);
+            m_pcapDumpHandle = LibPcapSafeNativeMethods.pcap_dump_open(Handle, m_pcapFile);
             if (m_pcapDumpHandle == IntPtr.Zero)
                 throw new PcapException("Error opening dump file '" + LastError + "'");
 
-            Active = true;
+            base.Open(configuration);
         }
 
         /// <summary>

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Interop.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Interop.cs
@@ -67,7 +67,7 @@ namespace SharpPcap.LibPcap
         internal extern static void pcap_freealldevs(IntPtr /* pcap_if_t * */ alldevs);
 
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /* pcap_t* */ pcap_open(
+        internal extern static PcapHandle /* pcap_t* */ pcap_open(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string dev,
             int packetLen,
             int flags,
@@ -77,48 +77,48 @@ namespace SharpPcap.LibPcap
         );
 
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /* pcap_t* */ pcap_create(
+        internal extern static PcapHandle /* pcap_t* */ pcap_create(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string dev,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder errbuf
         );
 
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /* pcap_t* */ pcap_open_offline(
+        internal extern static PcapHandle /* pcap_t* */ pcap_open_offline(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string/*const char* */ fname,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder/* char* */ errbuf
         );
 
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /* pcap_t* */ pcap_open_dead(int linktype, int snaplen);
+        internal extern static PcapHandle /* pcap_t* */ pcap_open_dead(int linktype, int snaplen);
 
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_set_buffer_size(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes);
+        internal extern static int pcap_set_buffer_size(PcapHandle /* pcap_t */ adapter, int bufferSizeInBytes);
 
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_set_immediate_mode(IntPtr /* pcap_t */ adapter, int immediate_mode);
+        internal extern static int pcap_set_immediate_mode(PcapHandle /* pcap_t */ adapter, int immediate_mode);
 
         /// <summary>Open a file to write packets. </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /*pcap_dumper_t * */ pcap_dump_open(
-            IntPtr /*pcap_t * */adaptHandle,
-             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string /*const char * */fname
+        internal extern static IntPtr /* pcap_dumper_t * */ pcap_dump_open(
+            PcapHandle /*pcap_t * */adaptHandle,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string /*const char * */ fname
         );
 
         /// <summary>
         ///  Save a packet to disk.  
         /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static void pcap_dump(IntPtr /*u_char * */user, IntPtr /*const struct pcap_pkthdr * */h, IntPtr /*const u_char * */sp);
+        internal extern static void pcap_dump(IntPtr /*u_char * */ user, IntPtr /*const struct pcap_pkthdr * */h, IntPtr /*const u_char * */sp);
 
         /// <summary> close the files associated with p and deallocates resources.</summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static void pcap_close(IntPtr /*pcap_t **/adaptHandle);
+        internal extern static void pcap_close(IntPtr /*pcap_t * */ adaptHandle);
 
         /// <summary>
         /// To avoid callback, this returns one packet at a time
         /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_next_ex(IntPtr /* pcap_t* */ adaptHandle, ref IntPtr /* **pkt_header */ header, ref IntPtr data);
+        internal extern static int pcap_next_ex(PcapHandle /* pcap_t* */ adaptHandle, ref IntPtr /* **pkt_header */ header, ref IntPtr data);
 
         /// <summary>
         /// Send a raw packet.<br/>
@@ -131,20 +131,20 @@ namespace SharpPcap.LibPcap
         /// <param name="size">the dimension of the buffer pointed by data</param>
         /// <returns>0 if the packet is succesfully sent, -1 otherwise.</returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_sendpacket(IntPtr /* pcap_t* */ adaptHandle, IntPtr data, int size);
+        internal extern static int pcap_sendpacket(PcapHandle /* pcap_t* */ adaptHandle, IntPtr data, int size);
 
         /// <summary>
         /// Compile a packet filter, converting an high level filtering expression (see Filtering expression syntax) in a program that can be interpreted by the kernel-level filtering engine. 
         /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_compile(
-            IntPtr /* pcap_t* */ adaptHandle, IntPtr /*bpf_program **/fp,
+            PcapHandle /* pcap_t* */ adaptHandle, IntPtr /*bpf_program * */ fp,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string /*char * */str,
             int optimize, UInt32 netmask
         );
 
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_setfilter(IntPtr /* pcap_t* */ adaptHandle, IntPtr /*bpf_program **/fp);
+        internal extern static int pcap_setfilter(PcapHandle /* pcap_t* */ adaptHandle, IntPtr /*bpf_program **/fp);
 
         /// <summary>
         /// Returns if a given filter applies to an offline packet. 
@@ -164,7 +164,7 @@ namespace SharpPcap.LibPcap
         /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler), MarshalCookie = "no_free")]
-        internal extern static string pcap_geterr(IntPtr /*pcap_t * */ adaptHandle);
+        internal extern static string pcap_geterr(PcapHandle /*pcap_t * */ adaptHandle);
 
         /// <summary>Returns a pointer to a string giving information about the version of the libpcap library being used; note that it contains more information than just a version number. </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
@@ -187,14 +187,14 @@ namespace SharpPcap.LibPcap
 
         /// <summary> Return the link layer of an adapter. </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_datalink(IntPtr /* pcap_t* */ adaptHandle);
+        internal extern static int pcap_datalink(PcapHandle /* pcap_t* */ adaptHandle);
 
         /// <summary>
         /// Set nonblocking mode. pcap_loop() and pcap_next() doesnt work in  nonblocking mode!
         /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_setnonblock(
-            IntPtr /* pcap_if_t** */ adaptHandle,
+            PcapHandle /* pcap_if_t** */ adaptHandle,
             int nonblock,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder /* char* */ errbuf
         );
@@ -204,7 +204,7 @@ namespace SharpPcap.LibPcap
         /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_getnonblock(
-            IntPtr /* pcap_if_t** */ adaptHandle,
+            PcapHandle /* pcap_if_t** */ adaptHandle,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder /* char* */ errbuf
         );
 
@@ -212,7 +212,7 @@ namespace SharpPcap.LibPcap
         /// Read packets until cnt packets are processed or an error occurs.
         /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_dispatch(IntPtr /* pcap_t* */ adaptHandle, int count, pcap_handler callback, IntPtr ptr);
+        internal extern static int pcap_dispatch(PcapHandle /* pcap_t* */ adaptHandle, int count, pcap_handler callback, IntPtr ptr);
 
         /// <summary>
         /// The delegate declaration for PcapHandler requires an UnmanagedFunctionPointer attribute.
@@ -231,7 +231,7 @@ namespace SharpPcap.LibPcap
         /// A <see cref="int"/>
         /// </returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_get_selectable_fd(IntPtr /* pcap_t* */ adaptHandle);
+        internal extern static int pcap_get_selectable_fd(PcapHandle /* pcap_t* */ adaptHandle);
 
         /// <summary>
         /// Fills in the pcap_stat structure passed to the function
@@ -247,7 +247,7 @@ namespace SharpPcap.LibPcap
         /// A <see cref="int"/>
         /// </returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_stats(IntPtr /* pcap_t* */ adapter, IntPtr /* struct pcap_stat* */ stat);
+        internal extern static int pcap_stats(PcapHandle /* pcap_t* */ adapter, IntPtr /* struct pcap_stat* */ stat);
 
         /// <summary>
         /// Returns the snapshot length
@@ -259,26 +259,26 @@ namespace SharpPcap.LibPcap
         /// A <see cref="int"/>
         /// </returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_snapshot(IntPtr /* pcap_t... */ adapter);
+        internal extern static int pcap_snapshot(PcapHandle /* pcap_t * */ adapter);
 
         /// <summary>
         /// pcap_set_rfmon() sets whether monitor mode should be set on a capture handle when the handle is activated.
         /// If rfmon is non-zero, monitor mode will be set, otherwise it will not be set.  
         /// </summary>
-        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <param name="p">A <see cref="PcapHandle"/></param>
         /// <param name="rfmon">A <see cref="int"/></param>
         /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
-        [DllImport(PCAP_DLL, EntryPoint = "_pcap_set_rfmon", CallingConvention = CallingConvention.Cdecl)]
-        private extern static int _pcap_set_rfmon(IntPtr /* pcap_t* */ p, int rfmon);
+        [DllImport(PCAP_DLL, EntryPoint = "pcap_set_rfmon", CallingConvention = CallingConvention.Cdecl)]
+        private extern static int _pcap_set_rfmon(PcapHandle /* pcap_t* */ p, int rfmon);
 
         /// <summary>
         /// pcap_set_snaplen() sets the snapshot length to be used on a capture handle when the handle is activated to snaplen.  
         /// </summary>
-        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <param name="p">A <see cref="PcapHandle"/></param>
         /// <param name="snaplen">A <see cref="int"/></param>
         /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_set_snaplen(IntPtr /* pcap_t* */ p, int snaplen);
+        internal extern static int pcap_set_snaplen(PcapHandle /* pcap_t* */ p, int snaplen);
 
         /// <summary>
         /// pcap_set_promisc() sets whether promiscuous mode should be set on a capture handle when the handle is activated. 
@@ -288,7 +288,7 @@ namespace SharpPcap.LibPcap
         /// <param name="promisc">A <see cref="int"/></param>
         /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_set_promisc(IntPtr /* pcap_t* */ p, int promisc);
+        internal extern static int pcap_set_promisc(PcapHandle /* pcap_t* */ p, int promisc);
 
         /// <summary>
         /// pcap_set_timeout() sets the packet buffer timeout that will be used on a capture handle when the handle is activated to to_ms, which is in units of milliseconds.
@@ -297,23 +297,23 @@ namespace SharpPcap.LibPcap
         /// <param name="to_ms">A <see cref="int"/></param>
         /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_set_timeout(IntPtr /* pcap_t* */ p, int to_ms);
+        internal extern static int pcap_set_timeout(PcapHandle /* pcap_t* */ p, int to_ms);
 
         /// <summary>
         /// pcap_activate() is used to activate a packet capture handle to look at packets on the network, with the options that were set on the handle being in effect.  
         /// </summary>
-        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <param name="p">A <see cref="PcapHandle"/></param>
         /// <returns>Returns 0 on success without warnings, a non-zero positive value on success with warnings, and a negative value on error. A non-zero return value indicates what warning or error condition occurred.</returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_activate(IntPtr /* pcap_t* */ p);
+        internal extern static int pcap_activate(PcapHandle /* pcap_t* */ p);
 
         /// <summary>
         /// Force a pcap_dispatch() or pcap_loop() call to return
         /// </summary>
-        /// <param name="p">A <see cref="IntPtr"/></param>
+        /// <param name="p">A <see cref="PcapHandle"/></param>
         /// <returns>Returns 0 on success without warnings, a non-zero positive value on success with warnings, and a negative value on error. A non-zero return value indicates what warning or error condition occurred.</returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_breakloop(IntPtr /* pcap_t* */ p);
+        internal extern static int pcap_breakloop(PcapHandle /* pcap_t* */ p);
 
         #region libpcap specific
         /// <summary>
@@ -330,7 +330,7 @@ namespace SharpPcap.LibPcap
         /// A <see cref="int"/>
         /// </returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_fileno(IntPtr /* pcap_t* p */ adapter);
+        internal extern static int pcap_fileno(PcapHandle /* pcap_t* p */ adapter);
         #endregion
 
         #region Send queue functions
@@ -348,7 +348,7 @@ namespace SharpPcap.LibPcap
         /// during the send. The error can be caused by a driver/adapter 
         /// problem or by an inconsistent/bogus send queue.</returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_sendqueue_transmit(IntPtr/*pcap_t * */p, ref pcap_send_queue queue, int sync);
+        internal extern static int pcap_sendqueue_transmit(PcapHandle /*pcap_t * */p, ref pcap_send_queue queue, int sync);
         #endregion
 
         #region Timestamp related functions
@@ -359,14 +359,14 @@ namespace SharpPcap.LibPcap
         /// <param name="precision"></param>
         /// <returns></returns>
         [DllImport(PCAP_DLL, EntryPoint = "pcap_set_tstamp_precision", CallingConvention = CallingConvention.Cdecl)]
-        private extern static int _pcap_set_tstamp_precision(IntPtr /* pcap_t* p */ adapter, int precision);
+        private extern static int _pcap_set_tstamp_precision(PcapHandle /* pcap_t* p */ adapter, int precision);
 
         /// <summary>
         /// Available since libpcap 1.5
         /// </summary>
         /// <param name="adapter"></param>
         [DllImport(PCAP_DLL, EntryPoint = "pcap_get_tstamp_precision", CallingConvention = CallingConvention.Cdecl)]
-        private extern static int _pcap_get_tstamp_precision(IntPtr /* pcap_t* p */ adapter);
+        private extern static int _pcap_get_tstamp_precision(PcapHandle /* pcap_t* p */ adapter);
 
         /// <summary>
         /// Available since libpcap 1.2
@@ -375,7 +375,7 @@ namespace SharpPcap.LibPcap
         /// <param name="tstamp_type"></param>
         /// <returns></returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_set_tstamp_type(IntPtr /* pcap_t* p */ adapter, int tstamp_type);
+        internal extern static int pcap_set_tstamp_type(PcapHandle /* pcap_t* p */ adapter, int tstamp_type);
 
         /// <summary>
         /// Available since libpcap 1.2
@@ -384,7 +384,7 @@ namespace SharpPcap.LibPcap
         /// <param name=""></param>
         /// <returns></returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_list_tstamp_types(IntPtr /* pcap_t* p */ adapter, ref IntPtr types_pointer_pointer);
+        internal extern static int pcap_list_tstamp_types(PcapHandle /* pcap_t* p */ adapter, ref IntPtr types_pointer_pointer);
 
         /// <summary>
         /// Since libpcap 1.2
@@ -428,7 +428,7 @@ namespace SharpPcap.LibPcap
         /// <param name="errbuf"></param>
         /// <returns></returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /* pcap_t* */ pcap_open_offline_with_tstamp_precision(
+        internal extern static PcapHandle /* pcap_t* */ pcap_open_offline_with_tstamp_precision(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string /* const char* */ fname,
             uint precision,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder /* char* */ errbuf
@@ -442,7 +442,7 @@ namespace SharpPcap.LibPcap
         /// <param name="precision"></param>
         /// <returns></returns>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static IntPtr /* pcap_t* */ pcap_open_dead_with_tstamp_precision(int type, int snaplen, uint precision);
+        internal extern static PcapHandle /* pcap_t* */ pcap_open_dead_with_tstamp_precision(int type, int snaplen, uint precision);
         #endregion
 
         /// <summary>
@@ -453,7 +453,7 @@ namespace SharpPcap.LibPcap
         /// <param name="bufferSizeInBytes"></param>
         /// <returns></returns>
         [DllImport(PCAP_DLL, EntryPoint = "pcap_setbuff", CallingConvention = CallingConvention.Cdecl)]
-        private extern static int _pcap_setbuff(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes);
+        private extern static int _pcap_setbuff(PcapHandle /* pcap_t */ adapter, int bufferSizeInBytes);
 
         /// <summary>
         /// Windows Only
@@ -463,7 +463,7 @@ namespace SharpPcap.LibPcap
         /// See https://www.tcpdump.org/manpages/pcap_set_immediate_mode.3pcap.html
         /// </summary>
         /// <param name="adapter">
-        /// A <see cref="IntPtr"/>
+        /// A <see cref="PcapHandle"/>
         /// </param>
         /// <param name="sizeInBytes">
         /// A <see cref="int"/>
@@ -472,7 +472,7 @@ namespace SharpPcap.LibPcap
         /// A <see cref="int"/>
         /// </returns>
         [DllImport(PCAP_DLL, EntryPoint = "pcap_setmintocopy", CallingConvention = CallingConvention.Cdecl)]
-        private extern static int _pcap_setmintocopy(IntPtr /* pcap_t */ adapter, int sizeInBytes);
+        private extern static int _pcap_setmintocopy(PcapHandle /* pcap_t */ adapter, int sizeInBytes);
 
         /// <summary>
         /// Windows Only
@@ -483,7 +483,7 @@ namespace SharpPcap.LibPcap
         /// Npcap specific method
         /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static int pcap_setmode(IntPtr/* pcap_t * */ p, int mode);
+        internal extern static int pcap_setmode(PcapHandle /* pcap_t * */ p, int mode);
 
     }
 }

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -35,13 +35,13 @@ namespace SharpPcap.LibPcap
     internal static partial class LibPcapSafeNativeMethods
     {
 
-        internal static int pcap_setbuff(IntPtr /* pcap_t */ adapter, int bufferSizeInBytes)
+        internal static int pcap_setbuff(PcapHandle /* pcap_t */ adapter, int bufferSizeInBytes)
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? _pcap_setbuff(adapter, bufferSizeInBytes)
                 : (int)PcapError.PlatformNotSupported;
         }
-        internal static int pcap_setmintocopy(IntPtr /* pcap_t */ adapter, int sizeInBytes)
+        internal static int pcap_setmintocopy(PcapHandle /* pcap_t */ adapter, int sizeInBytes)
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? _pcap_setmintocopy(adapter, sizeInBytes)
@@ -55,7 +55,7 @@ namespace SharpPcap.LibPcap
         /// <param name="p">A <see cref="IntPtr"/></param>
         /// <param name="rfmon">A <see cref="int"/></param>
         /// <returns>Returns 0 on success or PCAP_ERROR_ACTIVATED if called on a capture handle that has been activated.</returns>
-        internal static int pcap_set_rfmon(IntPtr /* pcap_t* */ p, int rfmon)
+        internal static int pcap_set_rfmon(PcapHandle /* pcap_t* */ p, int rfmon)
         {
             try
             {
@@ -76,7 +76,7 @@ namespace SharpPcap.LibPcap
         /// <param name="adapter"></param>
         /// <param name="precision"></param>
         /// <returns></returns>
-        internal static int pcap_set_tstamp_precision(IntPtr /* pcap_t* p */ adapter, int precision)
+        internal static int pcap_set_tstamp_precision(PcapHandle /* pcap_t* p */ adapter, int precision)
         {
             if (Pcap.LibpcapVersion < Libpcap_1_5)
             {
@@ -89,7 +89,7 @@ namespace SharpPcap.LibPcap
         /// Available since libpcap 1.5
         /// </summary>
         /// <param name="adapter"></param>
-        internal static int pcap_get_tstamp_precision(IntPtr /* pcap_t* p */ adapter)
+        internal static int pcap_get_tstamp_precision(PcapHandle /* pcap_t* p */ adapter)
         {
             if (Pcap.LibpcapVersion < Libpcap_1_5)
             {

--- a/SharpPcap/LibPcap/PcapDeviceCaptureLoop.cs
+++ b/SharpPcap/LibPcap/PcapDeviceCaptureLoop.cs
@@ -83,7 +83,7 @@ namespace SharpPcap.LibPcap
             {
                 threadCancellationTokenSource.Cancel();
                 threadCancellationTokenSource = new CancellationTokenSource();
-                LibPcapSafeNativeMethods.pcap_breakloop(PcapHandle);
+                LibPcapSafeNativeMethods.pcap_breakloop(Handle);
                 if (!captureThread.Join(StopCaptureTimeout))
                 {
                     try
@@ -176,7 +176,7 @@ namespace SharpPcap.LibPcap
                     continue;
                 }
 
-                int res = LibPcapSafeNativeMethods.pcap_dispatch(PcapHandle, m_pcapPacketCount, Callback, IntPtr.Zero);
+                int res = LibPcapSafeNativeMethods.pcap_dispatch(Handle, m_pcapPacketCount, Callback, IntPtr.Zero);
 
                 // pcap_dispatch() returns the number of packets read or, a status value if the value
                 // is negative

--- a/SharpPcap/LibPcap/PcapHandle.cs
+++ b/SharpPcap/LibPcap/PcapHandle.cs
@@ -1,0 +1,48 @@
+﻿/*
+This file is part of SharpPcap.
+
+SharpPcap is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SharpPcap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ * Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ * Copyright 2021 Ayoub Kaanich <kayoub5@live.com>
+ */
+
+using Microsoft.Win32.SafeHandles;
+using System;
+
+namespace SharpPcap.LibPcap
+{
+    public class PcapHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public PcapHandle()
+            : base(true)
+        {
+        }
+
+        private PcapHandle(IntPtr handle)
+            : base(true)
+        {
+            SetHandle(handle);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            LibPcapSafeNativeMethods.pcap_close(handle);
+            return true;
+        }
+
+        internal static readonly PcapHandle Invalid = new PcapHandle(IntPtr.Zero);
+    }
+}

--- a/SharpPcap/LibPcap/PcapStatistics.cs
+++ b/SharpPcap/LibPcap/PcapStatistics.cs
@@ -51,7 +51,7 @@ namespace SharpPcap.LibPcap
         /// pcap_t* for the adapter
         /// A <see cref="IntPtr"/>
         /// </param>
-        internal PcapStatistics(IntPtr pcap_t)
+        internal PcapStatistics(PcapHandle pcap_t)
         {
             IntPtr stat;
 

--- a/SharpPcap/LibPcap/SendQueue.cs
+++ b/SharpPcap/LibPcap/SendQueue.cs
@@ -35,22 +35,19 @@ namespace SharpPcap.LibPcap
 
         private static bool GetIsHardwareAccelerated()
         {
-            var handle = LibPcapSafeNativeMethods.pcap_open_dead(1, 60);
-            try
+            using (var handle = LibPcapSafeNativeMethods.pcap_open_dead(1, 60))
             {
-
-                pcap_send_queue queue = default;
-                LibPcapSafeNativeMethods.pcap_sendqueue_transmit(handle, ref queue, 0);
-                return true;
-            }
-            catch (TypeLoadException)
-            {
-                // Function pcap_sendqueue_transmit not found
-                return false;
-            }
-            finally
-            {
-                LibPcapSafeNativeMethods.pcap_close(handle);
+                try
+                {
+                    pcap_send_queue queue = default;
+                    LibPcapSafeNativeMethods.pcap_sendqueue_transmit(handle, ref queue, 0);
+                    return true;
+                }
+                catch (TypeLoadException)
+                {
+                    // Function pcap_sendqueue_transmit not found
+                    return false;
+                }
             }
         }
 
@@ -187,7 +184,7 @@ namespace SharpPcap.LibPcap
                     {
                         fixed (byte* p_packet = p)
                         {
-                            res = LibPcapSafeNativeMethods.pcap_sendpacket(device.PcapHandle, new IntPtr(p_packet), p.Length);
+                            res = LibPcapSafeNativeMethods.pcap_sendpacket(device.Handle, new IntPtr(p_packet), p.Length);
                         }
                     }
                     // Start Stopwatch after sending first packet
@@ -219,7 +216,7 @@ namespace SharpPcap.LibPcap
                     len = (uint)CurrentLength,
                     ptrBuff = new IntPtr(buf)
                 };
-                return LibPcapSafeNativeMethods.pcap_sendqueue_transmit(device.PcapHandle, ref pcap_queue, sync);
+                return LibPcapSafeNativeMethods.pcap_sendqueue_transmit(device.Handle, ref pcap_queue, sync);
             }
         }
 

--- a/SharpPcap/Statistics/StatisticsDevice.cs
+++ b/SharpPcap/Statistics/StatisticsDevice.cs
@@ -146,7 +146,7 @@ namespace SharpPcap.Statistics
             LiveDevice.Open(configuration);
             if (IsWindows)
             {
-                LibPcapSafeNativeMethods.pcap_setmode(LiveDevice.PcapHandle, (int)CaptureMode.Statistics);
+                LibPcapSafeNativeMethods.pcap_setmode(LiveDevice.Handle, (int)CaptureMode.Statistics);
             }
         }
 

--- a/Test/CheckFilterTest.cs
+++ b/Test/CheckFilterTest.cs
@@ -32,7 +32,7 @@ namespace Test
 
             var filterExpression = "arp";
             var mask = (uint)0;
-            var result = PcapDevice.CompileFilter(device.PcapHandle, filterExpression, mask, out IntPtr bpfProgram, out string errorString);
+            var result = PcapDevice.CompileFilter(device.Handle, filterExpression, mask, out IntPtr bpfProgram, out string errorString);
             Assert.IsTrue(result);
 
             var arp = new ARP(device);

--- a/Test/MemorySafetryTests.cs
+++ b/Test/MemorySafetryTests.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using PacketDotNet;
+using SharpPcap;
+using SharpPcap.LibPcap;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using static Test.TestHelper;
+
+namespace Test
+{
+    /// <summary>
+    /// Due to race conditions, it could happen that a device handle gets closed while being used by another thread
+    /// We need to be able to at least prevent memory corruption
+    /// If this test did what it should, you will see in the logs:
+    ///     "The active test run was aborted. Reason: Test host process crashed" 
+    /// We run each test 10 times in parallel, to make libpcap reuse freed memory and crash
+    /// </summary>
+    [TestFixture]
+    [Category("MemorySafetry")]
+    public class MemorySafetryTests
+    {
+
+        private readonly PcapInterface TestInterface = GetPcapDevice().Interface;
+
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void DisposeDuringCapture([Range(1, 10)] int _)
+        {
+            using var waitHandle = new AutoResetEvent(false);
+
+            // We can't use the same device for async capturing and sending
+
+            using var receiver = new LibPcapLiveDevice(TestInterface);
+            using var sender = new LibPcapLiveDevice(TestInterface);
+
+            // Configure sender
+            sender.Open();
+
+            // Configure receiver
+            receiver.Open(DeviceModes.Promiscuous);
+            receiver.Filter = "ether proto 0xDEAD";
+            receiver.OnPacketArrival += (d, e) =>
+            {
+                try
+                {
+                    // Most simple form, dipose device while capture is running
+                    Task.Run(receiver.Dispose).Wait();
+                    // Now try to access the memory of the packet
+                    Packet.ParsePacket(LinkLayers.Ethernet, e.Data.ToArray());
+                }
+                finally
+                {
+                    // Let test close
+                    waitHandle.Set();
+                }
+            };
+            receiver.StartCapture();
+
+            // Send the packets
+            var packet = EthernetPacket.RandomPacket();
+            packet.Type = (EthernetType)0xDEAD;
+            sender.SendPacket(packet);
+
+            // Wait for packets to arrive
+            Assert.IsTrue(waitHandle.WaitOne(5000));
+        }
+
+
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void DisposeDuringTransmit([Range(1, 10)] int _)
+        {
+            using var device = new LibPcapLiveDevice(TestInterface);
+            device.Open();
+            var queue = SendQueueTest.GetSendQueue(0xDEAD);
+            Task.Run(() =>
+            {
+                Thread.Sleep(SendQueueTest.DeltaMs);
+                device.Dispose();
+            });
+            try
+            {
+                queue.Transmit(device, SendQueueTransmitModes.Synchronized);
+            }
+            catch (ObjectDisposedException)
+            {
+                // We are good, we disposed mid sending and we deserve the exception
+            }
+        }
+    }
+}

--- a/Test/SendQueueTest.cs
+++ b/Test/SendQueueTest.cs
@@ -17,7 +17,7 @@ namespace Test
     {
         private const string Filter = "ether proto 0x1234";
         private const int PacketCount = 8;
-        private static readonly int DeltaMs = 10;
+        internal static readonly int DeltaMs = 10;
 
         /// <summary>
         /// Transmit with normal works correctly
@@ -196,11 +196,11 @@ namespace Test
         /// Helper method
         /// </summary>
         /// <returns></returns>
-        private static SendQueueWrapper GetSendQueue()
+        internal static SendQueueWrapper GetSendQueue(ushort ethertype = 0x1234)
         {
             var queue = new SendQueueWrapper(1024);
             var packet = EthernetPacket.RandomPacket();
-            packet.Type = (EthernetType)0x1234;
+            packet.Type = (EthernetType)ethertype;
             for (var i = 0; i < PacketCount; i++)
             {
                 Assert.IsTrue(queue.Add(packet.Bytes, 123456, i * DeltaMs * 1000));
@@ -208,7 +208,7 @@ namespace Test
             return queue;
         }
 
-        class SendQueueWrapper : SendQueue
+        internal class SendQueueWrapper : SendQueue
         {
             public SendQueueWrapper(int memSize) : base(memSize)
             {


### PR DESCRIPTION
Fixes #295
Same tests that crash in #305 are now passing here.

@KoenPlasmansLS could you test if this PR fixes your problem?

Other handles needs to be updated as well from `IntPtr` to `SafeHandle`, those should be addressed in other PRs otherwise this PR would be too big.

List of handles that needs updating (in the future)
* `pcap_dumper_t *`
* `bpf_program *`
* `pcap_pkthdr *`
* `pcap_stat *`
* `pcap_if_t *`
* `int **tstamp_typesp`