### PR TITLE
Fix for issue #314: Calling pcap_open() for certain flags of enum Dev…

### DIFF
--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Interop.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Interop.cs
@@ -43,6 +43,8 @@ namespace SharpPcap.LibPcap
         //       See http://www.mono-project.com/Interop_with_Native_Libraries#Library_Names
         private const string PCAP_DLL = "wpcap";
 
+        internal const int PCAP_ERROR_ACTIVATED = -4;
+
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_init(
             uint opts,
@@ -73,6 +75,16 @@ namespace SharpPcap.LibPcap
             int flags,
             int read_timeout,
             ref pcap_rmtauth rmtauth,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder errbuf
+        );
+
+            [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
+        internal extern static PcapHandle /* pcap_t* */ pcap_open(
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string dev,
+            int packetLen,
+            int flags,
+            int read_timeout,
+            IntPtr rmtauth, //allows to pass a null pointer
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder errbuf
         );
 


### PR DESCRIPTION
Updated  LibPcapDevice.Open().
It calls now pcap_open() if ceredentials are supplied or
the Mode contains other flags than DeviceMode.Promiscuous and DeviceMode.MaxResponsiveness.
Configuration parameters that can only set on an inactive device  are ignored in this case.
This are TimestampResolution, TimestampType, Monitor and BufferSize.
Otherwise calls pcap_create().
Add a pcap_open() overload that accepts a null pinter as auth parameter.

Run unit tests for .NET framework 4.8, platform x86 against Npcap 1.55 (see [Results.trx.zip](https://github.com/chmorgan/sharppcap/files/7185801/Results.trx.zip))
