### PR TITLE
Better coverage collection

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "codecov.tool": {
+      "version": "1.13.0",
+      "commands": [
+        "codecov"
+      ]
+    }
+  }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
   pool:
     vmImage: 'VS2017-Win2016'
   steps:
+  - checkout: self
   - pwsh: ./scripts/InstallNpcap.ps1
     env:
       npcap_oem_key: $(npcap_oem_key)
@@ -43,6 +44,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
+  - checkout: self
   - script: choco install -y winpcap
   - script: dotnet restore -s https://api.nuget.org/v3/index.json
   - script: bash scripts/test.sh --filter "TestCategory!=Timestamp"
@@ -51,6 +53,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
+  - checkout: self
   - pwsh: ./scripts/InstallNpcap.ps1
     env:
       npcap_oem_key: $(npcap_oem_key)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ jobs:
   steps:
   - script: sudo -E bash scripts/install-libpcap.sh
   - script: sudo -E bash scripts/test.sh
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - job: macos
   pool:
@@ -27,6 +29,8 @@ jobs:
   - script: sudo -E bash scripts/install-libpcap.sh
   - script: sudo sysctl -w net.inet.udp.maxdgram=65535
   - script: sudo -E bash scripts/test.sh
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - job: windows_2016_vs2017_npcap
   pool:
@@ -37,6 +41,8 @@ jobs:
       npcap_oem_key: $(npcap_oem_key)
   - script: dotnet restore -s https://api.nuget.org/v3/index.json
   - script: bash scripts/test.sh --filter "TestCategory!=RemotePcap"
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 # NOTE: Remove when npcap has rpcapd support
 - job: windows_2019_vs2019_winpcap
@@ -46,6 +52,8 @@ jobs:
   - script: choco install -y winpcap
   - script: dotnet restore -s https://api.nuget.org/v3/index.json
   - script: bash scripts/test.sh --filter "TestCategory!=Timestamp"
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - job: windows_2019_vs2019_npcap
   pool:
@@ -56,3 +64,5 @@ jobs:
       npcap_oem_key: $(npcap_oem_key)
   - script: dotnet restore -s https://api.nuget.org/v3/index.json
   - script: bash scripts/test.sh --filter "TestCategory!=RemotePcap"
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,6 @@ jobs:
   pool:
     vmImage: 'VS2017-Win2016'
   steps:
-  - checkout: self
   - pwsh: ./scripts/InstallNpcap.ps1
     env:
       npcap_oem_key: $(npcap_oem_key)
@@ -44,7 +43,6 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - checkout: self
   - script: choco install -y winpcap
   - script: dotnet restore -s https://api.nuget.org/v3/index.json
   - script: bash scripts/test.sh --filter "TestCategory!=Timestamp"
@@ -53,7 +51,6 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - checkout: self
   - pwsh: ./scripts/InstallNpcap.ps1
     env:
       npcap_oem_key: $(npcap_oem_key)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,10 @@
 codecov:
+  # Allow collecting coverage even if some CIs fail
+  require_ci_to_pass: no
   notify:
     # 4 for appveyor
     # 3 for azure pipelines
     # 1 for circleci
-    # 2 for travis
-    # Total = 10
+    # Total = 8
     # Tolerate one of the services being down (worst case appveyor)
-    after_n_builds: 6
+    after_n_builds: 4

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,9 +29,10 @@ then
     CODECOV_ARGS+=( --flag "$SYSTEM_JOBDISPLAYNAME" )
 fi
 
-if [ -n "$BUILD_SOURCEVERSION" ] # Azure Pipelines
+if [ -n "$SYSTEM_PULLREQUEST_SOURCECOMMITID" ] # Azure Pipelines
 then
-    CODECOV_ARGS+=( --sha "$BUILD_SOURCEVERSION" )
+    CODECOV_ARGS+=( --sha "$SYSTEM_PULLREQUEST_SOURCECOMMITID" )
+    CODECOV_ARGS+=( --branch "$SYSTEM_PULLREQUEST_SOURCEBRANCH" )
 fi
 
 dotnet tool restore

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -35,5 +35,7 @@ then
     CODECOV_ARGS+=( --branch "$SYSTEM_PULLREQUEST_SOURCEBRANCH" )
 fi
 
+env
+
 dotnet tool restore
 dotnet codecov ${CODECOV_ARGS[@]}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -23,10 +23,11 @@ dotnet test "${TEST_ARGS[@]}"
 
 # coverage
 
-CODECOV_ARGS=( -f '**\*.opencover.xml' )
+CODECOV_ARGS=( -f '**/*.opencover.xml' )
 if [ -n "$SYSTEM_JOBDISPLAYNAME" ]
 then
-    CODECOV_ARGS+=( -F "$SYSTEM_JOBDISPLAYNAME" )
+    CODECOV_ARGS+=( --flag "$SYSTEM_JOBDISPLAYNAME" )
 fi
 
-bash <(curl -s https://codecov.io/bash) "${CODECOV_ARGS[@]}"
+dotnet tool restore
+dotnet codecov ${CODECOV_ARGS[@]}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,4 +38,4 @@ fi
 env
 
 dotnet tool restore
-dotnet codecov ${CODECOV_ARGS[@]}
+dotnet codecov ${CODECOV_ARGS[@]} -t $CODECOV_TOKEN

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,5 +29,10 @@ then
     CODECOV_ARGS+=( --flag "$SYSTEM_JOBDISPLAYNAME" )
 fi
 
+if [ -n "$BUILD_SOURCEVERSION" ] # Azure Pipelines
+then
+    CODECOV_ARGS+=( --sha "$BUILD_SOURCEVERSION" )
+fi
+
 dotnet tool restore
 dotnet codecov ${CODECOV_ARGS[@]}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -35,7 +35,5 @@ then
     CODECOV_ARGS+=( --branch "$SYSTEM_PULLREQUEST_SOURCEBRANCH" )
 fi
 
-env
-
 dotnet tool restore
 dotnet codecov ${CODECOV_ARGS[@]}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,4 +38,4 @@ fi
 env
 
 dotnet tool restore
-dotnet codecov ${CODECOV_ARGS[@]} -t $CODECOV_TOKEN
+dotnet codecov ${CODECOV_ARGS[@]}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -35,5 +35,8 @@ then
     CODECOV_ARGS+=( --branch "$SYSTEM_PULLREQUEST_SOURCEBRANCH" )
 fi
 
+# Depending on CI, dotnet tool or bash may or may not work
+# Try them both, it won't change coverage
 dotnet tool restore
 dotnet codecov ${CODECOV_ARGS[@]}
+bash <(curl -s https://codecov.io/bash) "${CODECOV_ARGS[@]}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -35,8 +35,13 @@ then
     CODECOV_ARGS+=( --branch "$SYSTEM_PULLREQUEST_SOURCEBRANCH" )
 fi
 
-# Depending on CI, dotnet tool or bash may or may not work
-# Try them both, it won't change coverage
-dotnet tool restore
-dotnet codecov ${CODECOV_ARGS[@]}
-bash <(curl -s https://codecov.io/bash) "${CODECOV_ARGS[@]}"
+# Depending on CI, dotnet tool or bash should be used
+# This is temporary until codecov fixes CI detection in the dotnet tool
+
+if [ -n "$SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"  ]
+then
+    dotnet tool restore
+    dotnet codecov ${CODECOV_ARGS[@]}
+else
+    bash <(curl -s https://codecov.io/bash) "${CODECOV_ARGS[@]}"
+fi


### PR DESCRIPTION
On February 1, 2022, the codecov-bash uploader will be fully sunset and no longer function

https://github.com/codecov/codecov-bash

instead this PR uses https://www.nuget.org/packages/Codecov.Tool/