### PR TITLE
Add WinTap support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,7 @@ for:
     - choco install -y dotnet-sdk --version=5.0.400
     - ps: .\scripts\InstallNpcap.ps1
     - ps: .\scripts\install-winpkfilter.ps1
+    - choco install -y openvpn
   build_script:
     - dotnet build -c Release
   test_script:
@@ -37,6 +38,7 @@ for:
   install:
     - ps: .\scripts\InstallNpcap.ps1
     - ps: .\scripts\install-winpkfilter.ps1
+    - choco install -y openvpn
   build_script:
     - dotnet build -c Release
   test_script:

--- a/SharpPcap/BaseLiveDevice.cs
+++ b/SharpPcap/BaseLiveDevice.cs
@@ -1,0 +1,140 @@
+﻿/*
+This file is part of SharpPcap.
+
+SharpPcap is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SharpPcap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* 
+ * Copyright 2021 Ayoub Kaanich <kayoub5@live.com>
+ */
+
+using PacketDotNet;
+using SharpPcap.LibPcap;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SharpPcap
+{
+
+    /// <summary>
+    /// Helper base class for non Libpcap based devices
+    /// </summary>
+    public abstract class BaseLiveDevice : IDisposable
+    {
+
+        private CancellationTokenSource TokenSource;
+        private Task CaptureTask;
+        public bool Started => CaptureTask?.IsCompleted == false;
+
+        protected TimeSpan ReadTimeout { get; set; } = TimeSpan.FromSeconds(1);
+
+        public TimeSpan StopCaptureTimeout { get; set; } = TimeSpan.FromSeconds(1);
+
+        public ICaptureStatistics Statistics => null;
+
+        public TimestampResolution TimestampResolution => TimestampResolution.Microsecond;
+
+        public virtual LinkLayers LinkType => LinkLayers.Ethernet;
+
+        public event PacketArrivalEventHandler OnPacketArrival;
+        public event CaptureStoppedEventHandler OnCaptureStopped;
+
+        protected BpfProgram FilterProgram;
+        private string FilterValue;
+        public string Filter
+        {
+            get => FilterValue;
+            set
+            {
+                using (var pcapHandle = LibPcapSafeNativeMethods.pcap_open_dead((int)LinkType, Pcap.MAX_PACKET_SIZE))
+                {
+                    FilterProgram = BpfProgram.Create(pcapHandle, value);
+                    FilterValue = value;
+                }
+            }
+        }
+
+        protected void RaiseOnPacketArrival(PacketCapture capture)
+        {
+            if (FilterProgram?.Matches(capture.Data) ?? true)
+            {
+                OnPacketArrival?.Invoke(this, capture);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the next packet from a device
+        /// </summary>
+        /// <param name="e"></param>
+        /// <returns>Status of the operation</returns>
+        public GetPacketStatus GetNextPacket(out PacketCapture e)
+        {
+            var sw = Stopwatch.StartNew();
+            do
+            {
+                var status = GetUnfilteredPacket(out e, ReadTimeout - sw.Elapsed);
+                if (FilterProgram?.Matches(e.Data) ?? true)
+                {
+                    return status;
+                }
+            } while (sw.Elapsed < ReadTimeout);
+            e = default;
+            return GetPacketStatus.ReadTimeout;
+        }
+
+        protected abstract GetPacketStatus GetUnfilteredPacket(out PacketCapture e, TimeSpan timeout);
+        protected abstract void CaptureLoop(CancellationToken token);
+
+        public void StopCapture()
+        {
+            TokenSource?.Cancel();
+            TokenSource = null;
+        }
+
+        public void Capture()
+        {
+            CaptureLoop(default);
+        }
+
+        public void StartCapture()
+        {
+            if (OnPacketArrival == null)
+            {
+                throw new DeviceNotReadyException("No delegates assigned to OnPacketArrival, no where for captured packets to go.");
+            }
+            if (Started)
+            {
+                return;
+            }
+            CaptureTask = Task.Run(() =>
+            {
+                TokenSource?.Dispose();
+                TokenSource = new CancellationTokenSource();
+                CaptureLoop(TokenSource.Token);
+                OnCaptureStopped?.Invoke(this, CaptureStoppedEventStatus.CompletedWithoutError);
+            });
+        }
+
+        public virtual void Close()
+        {
+            StopCapture();
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
+    }
+}

--- a/SharpPcap/WinTap/NativeMethods.cs
+++ b/SharpPcap/WinTap/NativeMethods.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace SharpPcap.WinTap
+{
+    internal static class NativeMethods
+    {
+
+        internal static Version GetVersion(SafeFileHandle handle)
+        {
+            Span<byte> inBuffer = stackalloc byte[0];
+            Span<byte> outBuffer = stackalloc byte[12];
+            var retval = TapControl(handle, TapIoControl.GetVersion, inBuffer, ref outBuffer);
+            if (!retval)
+            {
+                return null;
+            }
+            var v = MemoryMarshal.Cast<byte, int>(outBuffer);
+            return new Version(v[0], v[1], v[2]);
+        }
+
+        internal static void SetMediaStatus(SafeFileHandle handle, bool connected)
+        {
+            int value = connected ? 1 : 0;
+            Span<byte> inBuffer = stackalloc byte[4];
+            Span<byte> outBuffer = stackalloc byte[4];
+            MemoryMarshal.Write(inBuffer, ref value);
+            var retval = TapControl(handle, TapIoControl.SetMediaStatus, inBuffer, ref outBuffer);
+            if (!retval)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+
+        private static unsafe bool TapControl(SafeFileHandle handle, TapIoControl code, Span<byte> inBuffer, ref Span<byte> outBuffer)
+        {
+            fixed (byte* inPtr = inBuffer, outPtr = outBuffer)
+            {
+                var controlCode = CTL_CODE(FILE_DEVICE_UNKNOWN, (uint)code, METHOD_BUFFERED, FILE_ANY_ACCESS);
+                var retval = DeviceIoControl(handle, controlCode,
+                    new IntPtr(inPtr), inBuffer.Length,
+                    new IntPtr(outPtr), outBuffer.Length,
+                    out var returnedBytes,
+                    IntPtr.Zero
+                );
+                outBuffer = outBuffer.Slice(0, returnedBytes);
+                return retval;
+            }
+        }
+
+        private const uint METHOD_BUFFERED = 0;
+        private const uint FILE_ANY_ACCESS = 0;
+        private const uint FILE_DEVICE_UNKNOWN = 0x00000022;
+
+        private static uint CTL_CODE(uint deviceType, uint function, uint method, uint access)
+        {
+            return ((deviceType << 16) | (access << 14) | (function << 2) | method);
+        }
+
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto,
+            CallingConvention = CallingConvention.StdCall,
+            SetLastError = true)]
+        internal static extern SafeFileHandle CreateFile(
+            string lpFileName,
+            WinFileAccess dwDesiredAccess,
+            uint dwShareMode,
+            IntPtr SecurityAttributes,
+            WinFileCreation dwCreationDisposition,
+            WinFileAttributes dwFlagsAndAttributes,
+            IntPtr hTemplateFile
+        );
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto,
+            CallingConvention = CallingConvention.StdCall,
+            SetLastError = true)]
+        internal static extern int GetFileAttributes(string lpFileName);
+
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool DeviceIoControl(
+            [In] SafeFileHandle hDevice,
+            [In] uint dwIoControlCode,
+            [In] IntPtr lpInBuffer,
+            [In] int nInBufferSize,
+            [Out] IntPtr lpOutBuffer,
+            [In] int nOutBufferSize,
+            out int lpBytesReturned,
+            [In] IntPtr lpOverlapped
+        );
+    }
+}

--- a/SharpPcap/WinTap/TapIoControl.cs
+++ b/SharpPcap/WinTap/TapIoControl.cs
@@ -1,0 +1,26 @@
+﻿namespace SharpPcap.WinTap
+{
+    enum TapIoControl
+    {
+        /* Present in 8.1 */
+
+        GetMac = 1,
+        GetVersion = 2,
+        GetMtu = 3,
+        GetInfo = 4,
+        ConfigPointToPoint = 5,
+        SetMediaStatus = 6,
+        ConfigDhcpMasq = 7,
+        GetLogLine = 8,
+        config_dhcp_set_Opt = 9,
+
+        /* Added in 8.2 */
+
+        /** obsoletes ConfigPointToPoint */
+        ConfigTun = 10,
+
+        /** Control whether 802.1Q headers are added for priority */
+        PriorityBehavior = 11,
+
+    }
+}

--- a/SharpPcap/WinTap/TapPriorityBehavior.cs
+++ b/SharpPcap/WinTap/TapPriorityBehavior.cs
@@ -1,0 +1,10 @@
+﻿namespace SharpPcap.WinTap
+{
+    enum TapPriorityBehavior
+    {
+        NoPriority = 0,
+        Enabled = 1,
+        AddAlways = 2,
+        Max = 2,
+    }
+}

--- a/SharpPcap/WinTap/WinFileAccess.cs
+++ b/SharpPcap/WinTap/WinFileAccess.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace SharpPcap.WinTap
+{
+    [Flags]
+    enum WinFileAccess : uint
+    {
+        GenericRead = 0x80000000,
+        GenericWrite = 0x40000000,
+        GenericExecute = 0x20000000,
+        GenericAll = 0x10000000,
+    }
+}

--- a/SharpPcap/WinTap/WinFileAttributes.cs
+++ b/SharpPcap/WinTap/WinFileAttributes.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace SharpPcap.WinTap
+{
+    [Flags]
+    enum WinFileAttributes
+    {
+        Readonly = 0x00000001,
+        Hidden = 0x00000002,
+        System = 0x00000004,
+        Directory = 0x00000010,
+        Archive = 0x00000020,
+        Device = 0x00000040,
+        Normal = 0x00000080,
+        Temporary = 0x00000100,
+        SparseFile = 0x00000200,
+        ReparsePoint = 0x00000400,
+        Compressed = 0x00000800,
+        Offline = 0x00001000,
+        NotContentIndexed = 0x00002000,
+        Encrypted = 0x00004000,
+    }
+
+}

--- a/SharpPcap/WinTap/WinFileCreation.cs
+++ b/SharpPcap/WinTap/WinFileCreation.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SharpPcap.WinTap
+{
+    [Flags]
+    enum WinFileCreation : uint
+    {
+        CreateNew = 1,
+        CreateAlways = 2,
+        OpenExisting = 3,
+        OpenAlways = 4,
+        TruncateExisting = 5,
+    }
+}

--- a/SharpPcap/WinTap/WinTapDevice.cs
+++ b/SharpPcap/WinTap/WinTapDevice.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.Win32.SafeHandles;
+using SharpPcap.WinpkFilter;
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Threading;
+namespace SharpPcap.WinTap
+{
+    public partial class WinTapDevice : BaseLiveDevice, ILiveDevice
+    {
+        private readonly NetworkInterface Interface;
+        private FileStream Stream;
+
+        protected SafeFileHandle Handle { get; set; } = new SafeFileHandle(IntPtr.Zero, false);
+
+        public string Name => "wintap:" + Interface.Name;
+
+        public string FriendlyName => Interface.Name;
+
+        public string Description => Interface.Description;
+
+        public string LastError => null;
+
+        public Version Version
+        {
+            get => NativeMethods.GetVersion(Handle);
+        }
+
+        public PhysicalAddress MacAddress => Interface.GetPhysicalAddress();
+
+        public WinTapDevice(NetworkInterface networkInterface)
+        {
+            this.Interface = networkInterface;
+        }
+
+        public static NetworkInterface[] GetTapInterfaces()
+        {
+            var nics = NetworkInterface.GetAllNetworkInterfaces();
+            return nics.Where(n => n.Description.StartsWith("TAP-Windows Adapter"))
+                .ToArray();
+        }
+
+        public void Open(DeviceConfiguration configuration)
+        {
+            if (!(Handle.IsClosed || Handle.IsInvalid))
+            {
+                return;
+            }
+            this.Handle = NativeMethods.CreateFile(@"\\.\Global\" + Interface.Id + ".tap",
+                WinFileAccess.GenericRead | WinFileAccess.GenericWrite,
+                0,
+                IntPtr.Zero,
+                WinFileCreation.OpenExisting,
+                WinFileAttributes.System,
+                IntPtr.Zero
+            );
+            if (Handle.IsInvalid)
+            {
+                throw new PcapException("Failed to open device");
+            }
+            NativeMethods.SetMediaStatus(Handle, true);
+            this.Stream = new FileStream(Handle, FileAccess.ReadWrite);
+        }
+
+        public override void Close()
+        {
+            base.Close();
+            Stream.Close();
+            Handle.Close();
+        }
+
+        private readonly byte[] ReadBuffer = new byte[0x4000];
+        protected override GetPacketStatus GetUnfilteredPacket(out PacketCapture e, TimeSpan timeout)
+        {
+            var cts = new CancellationTokenSource(timeout);
+            var task = Stream.ReadAsync(ReadBuffer, 0, ReadBuffer.Length, cts.Token);
+            task.Wait();
+
+            if (!task.IsFaulted)
+            {
+                if (task.Result == 0)
+                {
+                    e = default;
+                    return GetPacketStatus.NoRemainingPackets;
+                }
+                var data = new Span<byte>(ReadBuffer).Slice(0, task.Result);
+                e = new PacketCapture(this, new WinpkFilterHeader(), data);
+                return GetPacketStatus.PacketRead;
+            }
+            else
+            {
+                throw task.Exception;
+            }
+        }
+
+        protected override void CaptureLoop(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var task = Stream.ReadAsync(ReadBuffer, 0, ReadBuffer.Length, token);
+                task.Wait();
+                if (!task.IsFaulted)
+                {
+                    var data = new Span<byte>(ReadBuffer).Slice(0, task.Result);
+                    var p = new PacketCapture(this, new WinpkFilterHeader(), data);
+                    RaiseOnPacketArrival(p);
+                }
+            }
+        }
+
+        public void SendPacket(ReadOnlySpan<byte> p, ICaptureHeader header = null)
+        {
+            var data = p.ToArray();
+            Stream.Write(data, 0, data.Length);
+            Stream.Flush();
+        }
+    }
+}

--- a/SharpPcap/WinTap/WinTapHeader.cs
+++ b/SharpPcap/WinTap/WinTapHeader.cs
@@ -1,0 +1,13 @@
+﻿
+namespace SharpPcap.WinTap
+{
+    public class WinTapHeader : ICaptureHeader
+    {
+        public PosixTimeval Timeval { get; set; }
+
+        public WinTapHeader()
+        {
+            Timeval = new PosixTimeval();
+        }
+    }
+}

--- a/Test/WinTap/WinTapDeviceTest.cs
+++ b/Test/WinTap/WinTapDeviceTest.cs
@@ -1,0 +1,107 @@
+﻿using NUnit.Framework;
+using PacketDotNet;
+using SharpPcap;
+using SharpPcap.LibPcap;
+using SharpPcap.WinTap;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using static SharpPcap.LibPcap.PcapUnmanagedStructures;
+
+namespace Test.WinTap
+{
+    [TestFixture]
+    [Category("WinTap")]
+    [Platform("Win", Reason = "WinpkFilter driver is only available for Windows")]
+    public class WinTapDeviceTest
+    {
+
+        [Test]
+        public void Properties()
+        {
+            var nic = WinTapDevice.GetTapInterfaces().First();
+            using var device = new WinTapDevice(nic);
+
+            Assert.GreaterOrEqual(device.Version.Major, 9);
+            Assert.IsNotNull(device.Name);
+            Assert.IsNotNull(device.FriendlyName);
+            Assert.IsNull(device.Description);
+            Assert.IsNull(device.LastError);
+            Assert.IsNull(device.Filter);
+            Assert.AreEqual(LinkLayers.Ethernet, device.LinkType);
+            Assert.IsNotNull(device.MacAddress);
+            Assert.AreEqual(TimestampResolution.Microsecond, device.TimestampResolution);
+            Assert.IsNull(device.Statistics);
+        }
+
+        [Test]
+        public void TestReceive()
+        {
+            var nic = WinTapDevice.GetTapInterfaces().First();
+            var tapIp = GetIPAddress(nic);
+
+            // we need to provide our own IP and MAC, otherwise OS will ignore its own requests
+            var ipBytes = tapIp.GetAddressBytes();
+            ipBytes[3]++;
+            var testIp = new IPAddress(ipBytes);
+            var testMac = PhysicalAddress.Parse("001122334455");
+
+
+            using var tapDevice = new WinTapDevice(nic);
+            // Open TAP device first to ensure the virutal device is connected
+            tapDevice.Open();
+            using var pcapDevice = GetLibPcapDevice(nic);
+
+            tapDevice.Filter = "arp dst host " + tapIp;
+            var arp = new ARP(pcapDevice);
+
+            var mac = arp.Resolve(tapIp, testIp, testMac);
+            Assert.AreEqual(mac, tapDevice.MacAddress);
+
+            var retval = tapDevice.GetNextPacket(out var p);
+            Assert.AreEqual(GetPacketStatus.PacketRead, retval);
+            var arpPacket = Packet.ParsePacket(tapDevice.LinkType, p.Data.ToArray())
+                .Extract<ArpPacket>();
+            Assert.NotNull(arpPacket);
+        }
+
+        /// <summary>
+        /// Inject packets with one driver, and check it being received by the other
+        /// </summary>
+        [Test]
+        public void TestPcapTapExchange()
+        {
+            var nic = WinTapDevice.GetTapInterfaces().First();
+            using var tapDevice = new WinTapDevice(nic);
+            // Open TAP device first to ensure the virutal device is connected
+            tapDevice.Open();
+            using var pcapDevice = GetLibPcapDevice(nic);
+            PcapDeviceTest.CheckExchange(tapDevice, pcapDevice);
+        }
+
+        private static LibPcapLiveDevice GetLibPcapDevice(NetworkInterface nic)
+        {
+            var pcapInterface = new PcapInterface(new pcap_if
+            {
+                Name = @"\Device\NPF_" + nic.Id,
+            }, nic, null);
+            return new LibPcapLiveDevice(pcapInterface);
+        }
+
+        private static IPAddress GetIPAddress(NetworkInterface nic)
+        {
+            foreach (var ip in nic.GetIPProperties().UnicastAddresses)
+            {
+                if (ip.Address.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    return ip.Address;
+                }
+            }
+            return null;
+        }
+
+
+    }
+
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       npcap_oem_key: $(npcap_oem_key)
   - pwsh: .\scripts\install-winpkfilter.ps1
+  - script: choco install -y openvpn
   - script: dotnet restore -s https://api.nuget.org/v3/index.json
   - script: bash scripts/test.sh --filter "TestCategory!=RemotePcap"
     env:
@@ -52,6 +53,7 @@ jobs:
   steps:
   - script: choco install -y winpcap
   - pwsh: .\scripts\install-winpkfilter.ps1
+  - script: choco install -y openvpn
   - script: dotnet restore -s https://api.nuget.org/v3/index.json
   - script: bash scripts/test.sh --filter "TestCategory!=Timestamp"
     env:
@@ -65,6 +67,7 @@ jobs:
     env:
       npcap_oem_key: $(npcap_oem_key)
   - pwsh: .\scripts\install-winpkfilter.ps1
+  - script: choco install -y openvpn
   - script: dotnet restore -s https://api.nuget.org/v3/index.json
   - script: bash scripts/test.sh --filter "TestCategory!=RemotePcap"
     env:


### PR DESCRIPTION
# What's WinTap?
Driver that allows creating virtual adapters
https://github.com/OpenVPN/tap-windows6
# Why would it help?
This driver allows creating virtual networks, this means that you can now use SharpPcap to create VPNs and proxy applications.
This is different from Libpcap, WinDivert and WinpktFilter in one major detail, this driver allows creating and using virtual adapters, the others can only re-use existing adapters.